### PR TITLE
UpdatePreview の処理を整理

### DIFF
--- a/TilemapSplitter/TilemapSplitter/TilemapSplitterWindow.cs
+++ b/TilemapSplitter/TilemapSplitter/TilemapSplitterWindow.cs
@@ -102,23 +102,44 @@ public class TilemapSplitterWindow : EditorWindow
                 positions.Add(pos);
         var tiles = new HashSet<Vector3Int>(positions);
 
-        previewCrossTiles.Clear(); previewTTiles.Clear(); previewCornerTiles.Clear(); previewIsolateTiles.Clear(); previewVertTiles.Clear(); previewHorTiles.Clear();
+        ClearPreviewLists();
         foreach (var pos in positions)
-        {
-            bool up = tiles.Contains(pos + Vector3Int.up);
-            bool down = tiles.Contains(pos + Vector3Int.down);
-            bool left = tiles.Contains(pos + Vector3Int.left);
-            bool right = tiles.Contains(pos + Vector3Int.right);
-            int count = (up?1:0)+(down?1:0)+(left?1:0)+(right?1:0);
-            bool anyV = up||down, anyH = left||right;
-            if (count == 4) ApplyClassification(pos, settings[0].option, previewCrossTiles, previewVertTiles, previewHorTiles);
-            else if (count == 3) ApplyClassification(pos, settings[1].option, previewTTiles, previewVertTiles, previewHorTiles);
-            else if (count == 2 && anyV && anyH) ApplyClassification(pos, settings[2].option, previewCornerTiles, previewVertTiles, previewHorTiles);
-            else if (anyV && !anyH) previewVertTiles.Add(pos);
-            else if (anyH && !anyV) previewHorTiles.Add(pos);
-            else if (count == 0) ApplyClassification(pos, settings[3].option, previewIsolateTiles, previewVertTiles, previewHorTiles);
-        }
+            ClassifyTileNeighbors(pos, tiles);
         SceneView.RepaintAll();
+    }
+
+    private void ClearPreviewLists()
+    {
+        previewCrossTiles.Clear();
+        previewTTiles.Clear();
+        previewCornerTiles.Clear();
+        previewIsolateTiles.Clear();
+        previewVertTiles.Clear();
+        previewHorTiles.Clear();
+    }
+
+    private void ClassifyTileNeighbors(Vector3Int pos, HashSet<Vector3Int> tiles)
+    {
+        bool up = tiles.Contains(pos + Vector3Int.up);
+        bool down = tiles.Contains(pos + Vector3Int.down);
+        bool left = tiles.Contains(pos + Vector3Int.left);
+        bool right = tiles.Contains(pos + Vector3Int.right);
+        int count = (up ? 1 : 0) + (down ? 1 : 0) + (left ? 1 : 0) + (right ? 1 : 0);
+        bool anyV = up || down;
+        bool anyH = left || right;
+
+        if (count == 4)
+            ApplyClassification(pos, settings[0].option, previewCrossTiles, previewVertTiles, previewHorTiles);
+        else if (count == 3)
+            ApplyClassification(pos, settings[1].option, previewTTiles, previewVertTiles, previewHorTiles);
+        else if (count == 2 && anyV && anyH)
+            ApplyClassification(pos, settings[2].option, previewCornerTiles, previewVertTiles, previewHorTiles);
+        else if (anyV && !anyH)
+            previewVertTiles.Add(pos);
+        else if (anyH && !anyV)
+            previewHorTiles.Add(pos);
+        else if (count == 0)
+            ApplyClassification(pos, settings[3].option, previewIsolateTiles, previewVertTiles, previewHorTiles);
     }
 
     private void SplitTilemap()


### PR DESCRIPTION
## 概要
- UpdatePreview 内で行っていたタイル分類処理を `ClassifyTileNeighbors` として分離
- プレビュー用リストの初期化処理を `ClearPreviewLists` にまとめ、可読性を向上

------
https://chatgpt.com/codex/tasks/task_e_686cec23e758832aba13cd63ed5a2eb2