### PR TITLE
UTF-8 対応設定追加

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.cs text working-tree-encoding=UTF-8


### PR DESCRIPTION
## 概要
- `.gitattributes` を追加して `.cs` ファイルのエンコーディングを UTF-8 に固定

## テスト
- 既存のエディタ拡張が正常に日本語を表示できることを確認


------
https://chatgpt.com/codex/tasks/task_e_686d260cbdf8832aa9684f7620a71a36