### PR TITLE
TilemapSplitter の処理分割

### DIFF
--- a/TilemapSplitter/TilemapSplitter/TilemapClassifier.cs
+++ b/TilemapSplitter/TilemapSplitter/TilemapClassifier.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Tilemaps;
+
+[Flags]
+public enum ClassificationOption
+{
+    VerticalEdge   = 1 << 0,
+    HorizontalEdge = 1 << 1,
+    Independent    = 1 << 2,
+}
+
+public enum SettingType
+{
+    VerticalEdge = 0,
+    HorizontalEdge,
+    Cross,
+    TJunction,
+    Corner,
+    Isolate,
+}
+
+public class ClassificationSetting
+{
+    public ClassificationOption option;
+    public int    layer;
+    public string tag        = "Untagged";
+    public bool   canPreview = true;
+    public Color  color;
+}
+
+public class ClassificationResult
+{
+    public readonly List<Vector3Int> VerticalEdges   = new();
+    public readonly List<Vector3Int> HorizontalEdges = new();
+    public readonly List<Vector3Int> CrossTiles      = new();
+    public readonly List<Vector3Int> TJunctionTiles  = new();
+    public readonly List<Vector3Int> CornerTiles     = new();
+    public readonly List<Vector3Int> IsolateTiles    = new();
+}
+
+public static class TilemapClassifier
+{
+    public static ClassificationResult Classify(Tilemap tilemap, ClassificationSetting[] settings)
+    {
+        var result = new ClassificationResult();
+        var positions = new List<Vector3Int>();
+        foreach (var pos in tilemap.cellBounds.allPositionsWithin)
+        {
+            if (tilemap.GetTile(pos) != null) positions.Add(pos);
+        }
+
+        var tiles = new HashSet<Vector3Int>(positions);
+        foreach (var pos in positions)
+        {
+            ClassifyTileNeighbors(pos, tiles, settings, result);
+        }
+        return result;
+    }
+
+    private static void ClassifyTileNeighbors(Vector3Int pos, HashSet<Vector3Int> tiles,
+        ClassificationSetting[] settings, ClassificationResult result)
+    {
+        bool up    = tiles.Contains(pos + Vector3Int.up);
+        bool down  = tiles.Contains(pos + Vector3Int.down);
+        bool left  = tiles.Contains(pos + Vector3Int.left);
+        bool right = tiles.Contains(pos + Vector3Int.right);
+        bool anyV  = up   || down;
+        bool anyH  = left || right;
+        int count  = (up ? 1 : 0) + (down ? 1 : 0) + (left ? 1 : 0) + (right ? 1 : 0);
+
+        if (count == 4)
+        {
+            ApplyClassification(pos, settings[(int)SettingType.Cross].option,
+                result.CrossTiles, result.VerticalEdges, result.HorizontalEdges);
+        }
+        else if (count == 3)
+        {
+            ApplyClassification(pos, settings[(int)SettingType.TJunction].option,
+                result.TJunctionTiles, result.VerticalEdges, result.HorizontalEdges);
+        }
+        else if (count == 2 && anyV && anyH)
+        {
+            ApplyClassification(pos, settings[(int)SettingType.Corner].option,
+                result.CornerTiles, result.VerticalEdges, result.HorizontalEdges);
+        }
+        else if (anyV && anyH == false)
+        {
+            result.VerticalEdges.Add(pos);
+        }
+        else if (anyH && anyV == false)
+        {
+            result.HorizontalEdges.Add(pos);
+        }
+        else if (count == 0)
+        {
+            ApplyClassification(pos, settings[(int)SettingType.Isolate].option,
+                result.IsolateTiles, result.VerticalEdges, result.HorizontalEdges);
+        }
+    }
+
+    private static void ApplyClassification(Vector3Int pos, ClassificationOption opt,
+        List<Vector3Int> indep, List<Vector3Int> vList, List<Vector3Int> hList)
+    {
+        if (opt.HasFlag(ClassificationOption.VerticalEdge))   vList?.Add(pos);
+        if (opt.HasFlag(ClassificationOption.HorizontalEdge)) hList?.Add(pos);
+        if (opt.HasFlag(ClassificationOption.Independent))    indep?.Add(pos);
+    }
+}

--- a/TilemapSplitter/TilemapSplitter/TilemapCreator.cs
+++ b/TilemapSplitter/TilemapSplitter/TilemapCreator.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Tilemaps;
+
+public static class TilemapCreator
+{
+    private const string VerticalEdgeName   = "VerticalEdge";
+    private const string HorizontalEdgeName = "HorizontalEdge";
+    private const string CrossTileName      = "CrossTiles";
+    private const string TJunctionTileName  = "TJunctionTiles";
+    private const string CornerTileName     = "CornerTiles";
+    private const string IsolateTileName    = "IsolateTiles";
+
+    public static void Create(Tilemap original, ClassificationResult result,
+        ClassificationSetting[] settings, bool mergeEdges)
+    {
+        if (mergeEdges)
+        {
+            var merged = new List<Vector3Int>(result.VerticalEdges);
+            merged.AddRange(result.HorizontalEdges);
+            var s = settings[(int)SettingType.VerticalEdge];
+            CreateTiles(original, ClassificationOption.Independent, "EdgeTiles", merged, s.layer, s.tag);
+        }
+        else
+        {
+            var v = settings[(int)SettingType.VerticalEdge];
+            var h = settings[(int)SettingType.HorizontalEdge];
+            CreateTiles(original, v.option, VerticalEdgeName, result.VerticalEdges, v.layer, v.tag);
+            CreateTiles(original, h.option, HorizontalEdgeName, result.HorizontalEdges, h.layer, h.tag);
+        }
+
+        var cross   = settings[(int)SettingType.Cross];
+        var t       = settings[(int)SettingType.TJunction];
+        var corner  = settings[(int)SettingType.Corner];
+        var isolate = settings[(int)SettingType.Isolate];
+
+        CreateTiles(original, cross.option,   CrossTileName,     result.CrossTiles,   cross.layer,   cross.tag);
+        CreateTiles(original, t.option,       TJunctionTileName, result.TJunctionTiles, t.layer,       t.tag);
+        CreateTiles(original, corner.option,  CornerTileName,    result.CornerTiles,  corner.layer,  corner.tag);
+        CreateTiles(original, isolate.option, IsolateTileName,   result.IsolateTiles, isolate.layer, isolate.tag);
+    }
+
+    private static void CreateTiles(Tilemap original, ClassificationOption opt, string name,
+        List<Vector3Int> data, int layer, string tag)
+    {
+        if (data == null || data.Count == 0) return;
+
+        bool requiresIndependent = name == CrossTileName  || name == TJunctionTileName ||
+                                   name == CornerTileName || name == IsolateTileName;
+        if (requiresIndependent && opt.HasFlag(ClassificationOption.Independent) == false) return;
+
+        var obj = new GameObject(name, typeof(Tilemap), typeof(TilemapRenderer));
+        obj.transform.SetParent(original.transform.parent, false);
+        obj.layer = layer;
+        obj.tag   = tag;
+
+        var renderer = obj.GetComponent<TilemapRenderer>();
+        if (original.TryGetComponent<TilemapRenderer>(out var oriRenderer))
+        {
+            renderer.sortingLayerID = oriRenderer.sortingLayerID;
+            renderer.sortingOrder   = oriRenderer.sortingOrder;
+        }
+        else
+        {
+            Debug.LogWarning("Since TilemapRenderer is not attached to the split target, the TilemapRenderer of the generated object was generated with the default settings.");
+        }
+
+        var tm = obj.GetComponent<Tilemap>();
+        foreach (var p in data) tm.SetTile(p, original.GetTile(p));
+
+        Undo.RegisterCreatedObjectUndo(obj, "Create " + name);
+    }
+}

--- a/TilemapSplitter/TilemapSplitter/TilemapPreviewDrawer.cs
+++ b/TilemapSplitter/TilemapSplitter/TilemapPreviewDrawer.cs
@@ -1,0 +1,55 @@
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Tilemaps;
+
+public class TilemapPreviewDrawer
+{
+    private Tilemap tilemap;
+    private ClassificationSetting[] settings;
+    private ClassificationResult result;
+
+    public void Initialize(Tilemap tilemap, ClassificationSetting[] settings)
+    {
+        this.tilemap  = tilemap;
+        this.settings = settings;
+    }
+
+    public void SetResult(ClassificationResult result) => this.result = result;
+
+    public void Register()  => SceneView.duringSceneGui += OnSceneGUI;
+    public void Unregister() => SceneView.duringSceneGui -= OnSceneGUI;
+
+    private void OnSceneGUI(SceneView sv)
+    {
+        if (tilemap == null || result == null) return;
+
+        if (settings[(int)SettingType.VerticalEdge].canPreview)
+            DrawList(result.VerticalEdges, settings[(int)SettingType.VerticalEdge].color);
+        if (settings[(int)SettingType.HorizontalEdge].canPreview)
+            DrawList(result.HorizontalEdges, settings[(int)SettingType.HorizontalEdge].color);
+        if (settings[(int)SettingType.Cross].canPreview)
+            DrawList(result.CrossTiles, settings[(int)SettingType.Cross].color);
+        if (settings[(int)SettingType.TJunction].canPreview)
+            DrawList(result.TJunctionTiles, settings[(int)SettingType.TJunction].color);
+        if (settings[(int)SettingType.Corner].canPreview)
+            DrawList(result.CornerTiles, settings[(int)SettingType.Corner].color);
+        if (settings[(int)SettingType.Isolate].canPreview)
+            DrawList(result.IsolateTiles, settings[(int)SettingType.Isolate].color);
+    }
+
+    private void DrawList(System.Collections.Generic.List<Vector3Int> list, Color col)
+    {
+        Handles.color = new Color(col.r, col.g, col.b, 0.4f);
+        var cellSize = tilemap.cellSize;
+        foreach (var pos in list)
+        {
+            Vector3 worldPos = tilemap.CellToWorld(pos) + new Vector3(cellSize.x / 2f, cellSize.y / 2f);
+            Rect rect = new(
+                worldPos.x - cellSize.x / 2f,
+                worldPos.y - cellSize.y / 2f,
+                cellSize.x,
+                cellSize.y);
+            Handles.DrawSolidRectangleWithOutline(rect, Handles.color, Color.clear);
+        }
+    }
+}


### PR DESCRIPTION
## 概要
- Tilemap 分割ツールのコードを UI / 分類 / 生成 / プレビューの4要素に分割
- 新規 `TilemapClassifier` で分類処理を担当
- 新規 `TilemapCreator` で Tilemap オブジェクト生成を担当
- 新規 `TilemapPreviewDrawer` で SceneView 描画を担当
- `TilemapSplitterWindow` は UI のみを管理し、各処理クラスを利用するよう変更

## テスト
- `git status --short` で作業ツリーがクリーンであることを確認

------
https://chatgpt.com/codex/tasks/task_e_686f0a16f834832a887ac4743472992b