### PR TITLE
文字化けを防ぐためのエンコーディング設定追加

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+# top-most EditorConfig file
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
-*.cs text working-tree-encoding=UTF-8
+* text=auto eol=lf
+*.cs  text working-tree-encoding=UTF-8
+*.md  text working-tree-encoding=UTF-8


### PR DESCRIPTION
## 変更内容
- `.gitattributes` を更新し、全ファイルを UTF-8/LF で扱うよう設定
- `.editorconfig` を追加してエディタ側でも UTF-8/LF を統一

## 確認事項
- ビルドやテスト実行は特に設定されていないため、追加のチェックは行っていません

------
https://chatgpt.com/codex/tasks/task_e_686f16d6c0f0832aa665d87cec3ed7f3