### PR TITLE
TileShapeSetting用Dictionaryに変更

### DIFF
--- a/TilemapSplitter/TilemapSplitter/TileShapeClassifier.cs
+++ b/TilemapSplitter/TilemapSplitter/TileShapeClassifier.cs
@@ -50,7 +50,7 @@ namespace TilemapSplitter
         /// <summary>
         /// Compress the tilemap bounds to exclude empty rows and columns
         /// </summary>
-        public static ShapeCells Classify(Tilemap original, TileShapeSetting[] settings)
+        public static ShapeCells Classify(Tilemap original, Dictionary<TileShapeType, TileShapeSetting> settings)
         {
             var result = new ShapeCells();
 
@@ -91,7 +91,7 @@ namespace TilemapSplitter
         /// Classify the specified cell based on the four neighbouring cells
         /// </summary>
         private static void ClassifyCellNeighbors(Vector3Int cell, HashSet<Vector3Int> cells,
-            TileShapeSetting[] settings, ShapeCells result)
+            Dictionary<TileShapeType, TileShapeSetting> settings, ShapeCells result)
         {
             //Determine whether adjacent cells exist
             bool up    = cells.Contains(cell + Vector3Int.up);
@@ -106,13 +106,13 @@ namespace TilemapSplitter
             switch (neighborCount)
             {
                 case 4: //Cross
-                    ApplyShapeFlags(cell, settings[(int)TileShapeType.Cross].flags, result);
+                    ApplyShapeFlags(cell, settings[TileShapeType.Cross].flags, result);
                     break;
                 case 3: //TJunction
-                    ApplyShapeFlags(cell, settings[(int)TileShapeType.TJunction].flags, result);
+                    ApplyShapeFlags(cell, settings[TileShapeType.TJunction].flags, result);
                     break;
                 case 2 when anyV && anyH: //Corner
-                    ApplyShapeFlags(cell, settings[(int)TileShapeType.Corner].flags, result);
+                    ApplyShapeFlags(cell, settings[TileShapeType.Corner].flags, result);
                     break;
                 default:
                     if (anyV && anyH == false) //Vertical
@@ -125,7 +125,7 @@ namespace TilemapSplitter
                     }
                     else if (neighborCount == 0) //Isolate
                     {
-                        ApplyShapeFlags(cell, settings[(int)TileShapeType.Isolate].flags, result);
+                        ApplyShapeFlags(cell, settings[TileShapeType.Isolate].flags, result);
                     }
                     break;
             }

--- a/TilemapSplitter/TilemapSplitter/TilemapCreator.cs
+++ b/TilemapSplitter/TilemapSplitter/TilemapCreator.cs
@@ -16,30 +16,30 @@ namespace TilemapSplitter
         private const string IsolateTileName    = "IsolateTiles";
 
         public static void GenerateSplitTilemaps(Tilemap original, ShapeCells sCells,
-            TileShapeSetting[] settings, bool mergeEdges)
+            Dictionary<TileShapeType, TileShapeSetting> settings, bool mergeEdges)
         {
             if (mergeEdges)
             {
                 var mergedCells = new List<Vector3Int>(sCells.VerticalEdgesCells);
-                var v           = settings[(int)TileShapeType.VerticalEdge];
+                var v           = settings[TileShapeType.VerticalEdge];
                 mergedCells.AddRange(sCells.HorizontalEdgesCells);
                 CreateTilemapObjForCells(original, TileShapeFlags.Independent, MergeTileName,
                     mergedCells, v.layer, v.tag);
             }
             else
             {
-                var v = settings[(int)TileShapeType.VerticalEdge];
-                var h = settings[(int)TileShapeType.HorizontalEdge];
+                var v = settings[TileShapeType.VerticalEdge];
+                var h = settings[TileShapeType.HorizontalEdge];
                 CreateTilemapObjForCells(original, v.flags, VerticalEdgeName,
                     sCells.VerticalEdgesCells, v.layer, v.tag);
                 CreateTilemapObjForCells(original, h.flags, HorizontalEdgeName,
                     sCells.HorizontalEdgesCells, h.layer, h.tag);
             }
 
-            var cross   = settings[(int)TileShapeType.Cross];
-            var t       = settings[(int)TileShapeType.TJunction];
-            var corner  = settings[(int)TileShapeType.Corner];
-            var isolate = settings[(int)TileShapeType.Isolate];
+            var cross   = settings[TileShapeType.Cross];
+            var t       = settings[TileShapeType.TJunction];
+            var corner  = settings[TileShapeType.Corner];
+            var isolate = settings[TileShapeType.Isolate];
 
             CreateTilemapObjForCells(original, cross.flags, CrossTileName,
                 sCells.CrossCells, cross.layer, cross.tag);

--- a/TilemapSplitter/TilemapSplitter/TilemapPreviewDrawer.cs
+++ b/TilemapSplitter/TilemapSplitter/TilemapPreviewDrawer.cs
@@ -11,10 +11,10 @@ namespace TilemapSplitter
     internal class TilemapPreviewDrawer
     {
         private Tilemap tilemap;
-        private TileShapeSetting[] shapeSettings;
+        private Dictionary<TileShapeType, TileShapeSetting> shapeSettings;
         private ShapeCells shapeCells;
 
-        public void Setup(Tilemap original, TileShapeSetting[] settings)
+        public void Setup(Tilemap original, Dictionary<TileShapeType, TileShapeSetting> settings)
         {
             tilemap       = original;
             shapeSettings = settings;
@@ -31,12 +31,12 @@ namespace TilemapSplitter
                 shapeCells == null) return;
 
             //Read preview settings(color, visibility) for each tile classification
-            var v       = shapeSettings[(int)TileShapeType.VerticalEdge];
-            var h       = shapeSettings[(int)TileShapeType.HorizontalEdge];
-            var cross   = shapeSettings[(int)TileShapeType.Cross];
-            var t       = shapeSettings[(int)TileShapeType.TJunction];
-            var corner  = shapeSettings[(int)TileShapeType.Corner];
-            var isolate = shapeSettings[(int)TileShapeType.Isolate];
+            var v       = shapeSettings[TileShapeType.VerticalEdge];
+            var h       = shapeSettings[TileShapeType.HorizontalEdge];
+            var cross   = shapeSettings[TileShapeType.Cross];
+            var t       = shapeSettings[TileShapeType.TJunction];
+            var corner  = shapeSettings[TileShapeType.Corner];
+            var isolate = shapeSettings[TileShapeType.Isolate];
 
             //Draw each cell only if its preview flag is enabled, using the specified preview color
             var previewSettings = new (List<Vector3Int> cells, Color c, bool canPreview)[]

--- a/TilemapSplitter/TilemapSplitter/TilemapSplitterWindow.cs
+++ b/TilemapSplitter/TilemapSplitter/TilemapSplitterWindow.cs
@@ -2,22 +2,23 @@ namespace TilemapSplitter
 {
     using UnityEditor;
     using UnityEditor.UIElements;
+    using System.Collections.Generic;
     using UnityEngine;
     using UnityEngine.Tilemaps;
     using UnityEngine.UIElements;
 
     internal class TilemapSplitterWindow : EditorWindow
     {
-        private readonly TileShapeSetting[] settings = new TileShapeSetting[6]
+        private readonly Dictionary<TileShapeType, TileShapeSetting> settings = new()
         {
-            new() { flags = TileShapeFlags.VerticalEdge,   previewColor = Color.green  },
-            new() { flags = TileShapeFlags.HorizontalEdge, previewColor = Color.yellow },
-            new() { flags = TileShapeFlags.Independent,    previewColor = Color.red    },
-            new() { flags = TileShapeFlags.Independent,    previewColor = Color.blue   },
-            new() { flags = TileShapeFlags.Independent,    previewColor = Color.cyan   },
-            new() { flags = TileShapeFlags.Independent,    previewColor = Color.magenta },
+            [TileShapeType.VerticalEdge]   = new() { flags = TileShapeFlags.VerticalEdge,   previewColor = Color.green  },
+            [TileShapeType.HorizontalEdge] = new() { flags = TileShapeFlags.HorizontalEdge, previewColor = Color.yellow },
+            [TileShapeType.Cross]          = new() { flags = TileShapeFlags.Independent,    previewColor = Color.red    },
+            [TileShapeType.TJunction]      = new() { flags = TileShapeFlags.Independent,    previewColor = Color.blue   },
+            [TileShapeType.Corner]         = new() { flags = TileShapeFlags.Independent,    previewColor = Color.cyan   },
+            [TileShapeType.Isolate]        = new() { flags = TileShapeFlags.Independent,    previewColor = Color.magenta },
         };
-        private TileShapeSetting GetShapeSetting(TileShapeType t) => settings[(int)t];
+        private TileShapeSetting GetShapeSetting(TileShapeType t) => settings[t];
 
         private Foldout verticalEdgeFoldOut;
         private Foldout horizontalEdgeFoldOut;


### PR DESCRIPTION
## 概要
TileShapeSetting の管理方法を配列から `Dictionary<TileShapeType, TileShapeSetting>` へ変更しました。これにより列挙値の追加・順序変更に対して安全になります。

## 主な変更点
- `TilemapSplitterWindow` で設定配列を Dictionary に置き換え
- `TileShapeClassifier`/`TilemapCreator`/`TilemapPreviewDrawer` の API を Dictionary 対応へ修正
- それぞれのアクセス箇所をインデクサからキー指定に変更

------
https://chatgpt.com/codex/tasks/task_e_68725fd91e28832a9f12cf93e9a0b6ff