### PR TITLE
コライダー自動付与オプションの追加

### DIFF
--- a/TilemapSplitter/TilemapSplitter/TilemapCreator.cs
+++ b/TilemapSplitter/TilemapSplitter/TilemapCreator.cs
@@ -16,7 +16,8 @@ namespace TilemapSplitter
         private const string IsolateObjName    = "IsolateTiles";
 
         public static void GenerateSplitTilemaps(Tilemap source, ShapeCells sc,
-            Dictionary<ShapeType, ShapeSetting> settings, bool mergeEdges)
+            Dictionary<ShapeType, ShapeSetting> settings, bool mergeEdges,
+            bool attachCollider)
         {
             if (mergeEdges)
             {
@@ -24,28 +25,36 @@ namespace TilemapSplitter
                 var v           = settings[ShapeType.VerticalEdge];
                 v.flags         = ShapeFlags.Independent;
                 mergedCells.AddRange(sc.HorizontalCells);
-                CreateTilemapObjForCells(source, mergedCells, v, MergeObjName);
+                CreateTilemapObjForCells(source, mergedCells, v, MergeObjName,
+                    attachCollider);
             }
             else
             {
                 var v = settings[ShapeType.VerticalEdge];
                 var h = settings[ShapeType.HorizontalEdge];
-                CreateTilemapObjForCells(source, sc.VerticalCells, v, VerticalObjName);
-                CreateTilemapObjForCells(source, sc.HorizontalCells, h, HorizontalObjName);
+                CreateTilemapObjForCells(source, sc.VerticalCells,   v,
+                    VerticalObjName,   attachCollider);
+                CreateTilemapObjForCells(source, sc.HorizontalCells, h,
+                    HorizontalObjName, attachCollider);
             }
 
             var cross   = settings[ShapeType.Cross];
             var t       = settings[ShapeType.TJunction];
             var corner  = settings[ShapeType.Corner];
             var isolate = settings[ShapeType.Isolate];
-            CreateTilemapObjForCells(source, sc.CrossCells,     cross,   CrossObjName);
-            CreateTilemapObjForCells(source, sc.TJunctionCells, t,       TJunctionObjName);
-            CreateTilemapObjForCells(source, sc.CornerCells,    corner,  CornerObjName);
-            CreateTilemapObjForCells(source, sc.IsolateCells,   isolate, IsolateObjName);
+            CreateTilemapObjForCells(source, sc.CrossCells,     cross,
+                CrossObjName,    attachCollider);
+            CreateTilemapObjForCells(source, sc.TJunctionCells, t,
+                TJunctionObjName, attachCollider);
+            CreateTilemapObjForCells(source, sc.CornerCells,    corner,
+                CornerObjName,   attachCollider);
+            CreateTilemapObjForCells(source, sc.IsolateCells,   isolate,
+                IsolateObjName,  attachCollider);
         }
 
-        private static void CreateTilemapObjForCells(Tilemap source, List<Vector3Int> cells,
-            ShapeSetting setting, string name)
+        private static void CreateTilemapObjForCells(Tilemap source,
+            List<Vector3Int> cells, ShapeSetting setting, string name,
+            bool attachCollider)
         {
             if (cells == null || cells.Count == 0) return;
 
@@ -85,6 +94,15 @@ namespace TilemapSplitter
                 tm.SetTile(cell,  source.GetTile(cell));
                 tm.SetColor(cell, source.GetColor(cell));
                 tm.SetTransformMatrix(cell, source.GetTransformMatrix(cell));
+            }
+
+            if (attachCollider)
+            {
+                var tmCollider = obj.AddComponent<TilemapCollider2D>();
+                tmCollider.usedByComposite = true;
+                var rb = obj.AddComponent<Rigidbody2D>();
+                rb.bodyType = RigidbodyType2D.Static;
+                obj.AddComponent<CompositeCollider2D>();
             }
 
             Undo.RegisterCreatedObjectUndo(obj, "GenerateSplitTilemaps " + name);

--- a/TilemapSplitter/TilemapSplitter/TilemapSplitterWindow.cs
+++ b/TilemapSplitter/TilemapSplitter/TilemapSplitterWindow.cs
@@ -35,7 +35,8 @@ namespace TilemapSplitter
         private ShapeCells shapeCells = new();
         private readonly TilemapPreviewDrawer previewDrawer = new();
 
-        private bool canMergeEdges = false;
+        private bool canMergeEdges  = false;
+        private bool attachCollider = false;
         private bool isRefreshingPreview = false;
 
         [MenuItem("Tools/TilemapSplitter")]
@@ -93,6 +94,11 @@ namespace TilemapSplitter
             resetButton.text            = "Reset Settings";
             resetButton.style.marginTop = 5;
             container.Add(resetButton);
+
+            var attachToggle = new Toggle("Attach Colliders");
+            attachToggle.value = attachCollider;
+            attachToggle.RegisterValueChangedCallback(evt => attachCollider = evt.newValue);
+            container.Add(attachToggle);
 
             //Create Vertical, Horizontal Edge Shape Settings UI
             var mergeToggle = new Toggle("Merge VerticalEdge, HorizontalEdge");
@@ -260,7 +266,8 @@ namespace TilemapSplitter
 
             while (e.MoveNext()) yield return null;
 
-            TilemapCreator.GenerateSplitTilemaps(source, shapeCells, settingsDict, canMergeEdges);
+            TilemapCreator.GenerateSplitTilemaps(source, shapeCells, settingsDict,
+                canMergeEdges, attachCollider);
             RefreshPreview();
         }
 
@@ -320,7 +327,8 @@ namespace TilemapSplitter
                 EditorPrefs.DeleteKey(CreateKey("SourcePath"));
             }
 
-            EditorPrefs.SetBool(CreateKey("CanMergeEdges"), canMergeEdges);
+            EditorPrefs.SetBool(CreateKey("CanMergeEdges"),  canMergeEdges);
+            EditorPrefs.SetBool(CreateKey("AttachCollider"), attachCollider);
 
             foreach (var kv in settingsDict)
             {
@@ -342,7 +350,8 @@ namespace TilemapSplitter
                 source = AssetDatabase.LoadAssetAtPath<Tilemap>(path);
             }
 
-            canMergeEdges = EditorPrefs.GetBool(CreateKey("CanMergeEdges"), canMergeEdges);
+            canMergeEdges  = EditorPrefs.GetBool(CreateKey("CanMergeEdges"), canMergeEdges);
+            attachCollider = EditorPrefs.GetBool(CreateKey("AttachCollider"), attachCollider);
 
             foreach (var kv in settingsDict)
             {
@@ -364,6 +373,7 @@ namespace TilemapSplitter
         {
             EditorPrefs.DeleteKey(CreateKey("SourcePath"));
             EditorPrefs.DeleteKey(CreateKey("CanMergeEdges"));
+            EditorPrefs.DeleteKey(CreateKey("AttachCollider"));
 
             foreach (ShapeType type in System.Enum.GetValues(typeof(ShapeType)))
             {
@@ -375,9 +385,10 @@ namespace TilemapSplitter
                 EditorPrefs.DeleteKey(CreateKey($"{name}.Color"));
             }
 
-            settingsDict  = CreateDefaultSettings();
-            source        = null;
-            canMergeEdges = false;
+            settingsDict   = CreateDefaultSettings();
+            source         = null;
+            canMergeEdges  = false;
+            attachCollider = false;
         }
 
         #endregion


### PR DESCRIPTION
## 概要
- 設定ウィンドウに「Attach Colliders」トグルを追加
- 生成される Tilemap に TilemapCollider2D と CompositeCollider2D を自動追加するオプションを実装
- 設定値は EditorPrefs に保存

## テスト
- コマンド実行環境に C# コンパイラが無くビルド不可
- `apt-get update` はネットワーク制限で失敗

------
https://chatgpt.com/codex/tasks/task_e_6873b2b5bfc8832a8642fed50e758100