### PR TITLE
Hexagon分類の改善

### DIFF
--- a/Packages/com.sunagimo.tilemapsplitter/Editor/TilemapSplitterWindow.cs
+++ b/Packages/com.sunagimo.tilemapsplitter/Editor/TilemapSplitterWindow.cs
@@ -360,7 +360,7 @@ namespace TilemapSplitter
             if (isHex)
             {
                 hexShapeCells = new ShapeCells_Hex();
-                e = TileShapeClassifier.ClassifyCoroutine_Hex(source, settingsDict_hex, hexShapeCells);
+                e = TileShapeClassifier.ClassifyCoroutine_Hex(source, settingsDict_hex, hexShapeCells, HexOrientation.PointTop);
             }
             else
             {
@@ -396,7 +396,7 @@ namespace TilemapSplitter
                 if (isHex)
                 {
                     hexShapeCells = new ShapeCells_Hex();
-                    e = TileShapeClassifier.ClassifyCoroutine_Hex(source, settingsDict_hex, hexShapeCells);
+                    e = TileShapeClassifier.ClassifyCoroutine_Hex(source, settingsDict_hex, hexShapeCells, HexOrientation.PointTop);
                 }
                 else
                 {


### PR DESCRIPTION
## 概要
Hexagon 形状の分類ロジックにオリエンテーション(PointTop/FlatTop)を考慮できる仕組みを追加しました。これにより従来発生していた左右接続時の誤分類や Full 判定漏れを抑制します。

## 主な変更点
- `HexOrientation` 列挙体と各オリエンテーション用近傍オフセットを実装
- `GetNeighborOffsets` を拡張し、セル単位で適切な近傍を取得
- `ClassifyCoroutine_Hex` にオリエンテーション引数を追加し、呼び出し側を更新

## 影響範囲
`TileShapeClassifier` と `TilemapSplitterWindow` のみの変更であり、既存の矩形タイルマップ処理には影響しません。


------
https://chatgpt.com/codex/tasks/task_e_688858025724832a9053c7b1915e9eac