### PR TITLE
六角形タイル分類を隣接数のみで実装

### DIFF
--- a/Packages/com.sunagimo.tilemapsplitter/Editor/TileShapeClassifier.cs
+++ b/Packages/com.sunagimo.tilemapsplitter/Editor/TileShapeClassifier.cs
@@ -27,12 +27,13 @@ namespace TilemapSplitter
 
     internal enum ShapeType_Hex
     {
-        Full = 0,
-        Junction,
-        Corner,
-        Edge,
+        Isolate = 0,
         Tip,
-        Isolate,
+        Edge,
+        Junction3,
+        Junction4,
+        Junction5,
+        Full,
     }
 
     internal class ShapeSetting
@@ -59,12 +60,13 @@ namespace TilemapSplitter
 
     internal class ShapeCells_Hex
     {
-        public readonly List<Vector3Int> Full     = new();
-        public readonly List<Vector3Int> Junction = new();
-        public readonly List<Vector3Int> Corner   = new();
-        public readonly List<Vector3Int> Edge     = new();
-        public readonly List<Vector3Int> Tip      = new();
-        public readonly List<Vector3Int> Isolate  = new();
+        public readonly List<Vector3Int> Isolate   = new();
+        public readonly List<Vector3Int> Tip       = new();
+        public readonly List<Vector3Int> Edge      = new();
+        public readonly List<Vector3Int> Junction3 = new();
+        public readonly List<Vector3Int> Junction4 = new();
+        public readonly List<Vector3Int> Junction5 = new();
+        public readonly List<Vector3Int> Full      = new();
     }
 
     internal static class TileShapeClassifier
@@ -211,12 +213,13 @@ namespace TilemapSplitter
         public static IEnumerator ClassifyCoroutine_Hex(Tilemap source,
             Dictionary<ShapeType_Hex, ShapeSetting> settings, ShapeCells_Hex sc, int batch = 100)
         {
-            sc.Full.Clear();
-            sc.Junction.Clear();
-            sc.Corner.Clear();
-            sc.Edge.Clear();
-            sc.Tip.Clear();
             sc.Isolate.Clear();
+            sc.Tip.Clear();
+            sc.Edge.Clear();
+            sc.Junction3.Clear();
+            sc.Junction4.Clear();
+            sc.Junction5.Clear();
+            sc.Full.Clear();
 
             source.CompressBounds();
 
@@ -347,41 +350,26 @@ namespace TilemapSplitter
         private static void Classify_Hex(Vector3Int cell, bool[] exist, int neighborCount,
             Dictionary<ShapeType_Hex, ShapeSetting> settings, ShapeCells_Hex sc)
         {
-            int mask = 0;
-            for (int i = 0; i < exist.Length; i++)
-            {
-                if (exist[i]) mask |= 1 << i;
-            }
-
             switch (neighborCount)
             {
                 case 6:
                     ApplyShapeFlags_Hex(cell, settings[ShapeType_Hex.Full].flags, sc, sc.Full);
                     break;
-
                 case 5:
+                    ApplyShapeFlags_Hex(cell, settings[ShapeType_Hex.Junction5].flags, sc, sc.Junction5);
+                    break;
                 case 4:
-                    ApplyShapeFlags_Hex(cell, settings[ShapeType_Hex.Junction].flags, sc, sc.Junction);
+                    ApplyShapeFlags_Hex(cell, settings[ShapeType_Hex.Junction4].flags, sc, sc.Junction4);
                     break;
-
                 case 3:
-                    if (HasConsecutiveBits(mask, 3))
-                        ApplyShapeFlags_Hex(cell, settings[ShapeType_Hex.Corner].flags, sc, sc.Corner);
-                    else
-                        ApplyShapeFlags_Hex(cell, settings[ShapeType_Hex.Junction].flags, sc, sc.Junction);
+                    ApplyShapeFlags_Hex(cell, settings[ShapeType_Hex.Junction3].flags, sc, sc.Junction3);
                     break;
-
                 case 2:
-                    if (IsOpposite(mask))
-                        ApplyShapeFlags_Hex(cell, settings[ShapeType_Hex.Edge].flags, sc, sc.Edge);
-                    else
-                        ApplyShapeFlags_Hex(cell, settings[ShapeType_Hex.Corner].flags, sc, sc.Corner);
+                    ApplyShapeFlags_Hex(cell, settings[ShapeType_Hex.Edge].flags, sc, sc.Edge);
                     break;
-
                 case 1:
                     ApplyShapeFlags_Hex(cell, settings[ShapeType_Hex.Tip].flags, sc, sc.Tip);
                     break;
-
                 default:
                     ApplyShapeFlags_Hex(cell, settings[ShapeType_Hex.Isolate].flags, sc, sc.Isolate);
                     break;

--- a/Packages/com.sunagimo.tilemapsplitter/Editor/TilemapCreator.cs
+++ b/Packages/com.sunagimo.tilemapsplitter/Editor/TilemapCreator.cs
@@ -16,11 +16,12 @@ namespace TilemapSplitter
         private const string CornerObjName     = "CornerTiles";
         private const string IsolateObjName    = "IsolateTiles";
         //For Hexagon
-        private const string FullObjName       = "FullTiles";
-        private const string JunctionObjName   = "JunctionTiles";
-        private const string HexCornerObjName  = "HexCornerTiles";
-        private const string HexEdgeObjName    = "HexEdgeTiles";
-        private const string TipObjName        = "TipTiles";
+        private const string FullObjName      = "FullTiles";
+        private const string Junction5ObjName = "Junction5Tiles";
+        private const string Junction4ObjName = "Junction4Tiles";
+        private const string Junction3ObjName = "Junction3Tiles";
+        private const string HexEdgeObjName   = "HexEdgeTiles";
+        private const string TipObjName       = "TipTiles";
 
         public static void GenerateSplitTilemaps_Rect(Tilemap source, ShapeCells_Rect sc,
             Dictionary<ShapeType_Rect, ShapeSetting> settings, bool mergeEdges, bool canAttachCollider)
@@ -54,12 +55,13 @@ namespace TilemapSplitter
         public static void GenerateSplitTilemaps_Hex(Tilemap source, ShapeCells_Hex sc,
             Dictionary<ShapeType_Hex, ShapeSetting> settings, bool canAttachCollider)
         {
-            CreateTilemapObjForCells(source, sc.Full,     settings[ShapeType_Hex.Full],     FullObjName,     canAttachCollider);
-            CreateTilemapObjForCells(source, sc.Junction, settings[ShapeType_Hex.Junction], JunctionObjName, canAttachCollider);
-            CreateTilemapObjForCells(source, sc.Corner,   settings[ShapeType_Hex.Corner],   HexCornerObjName,canAttachCollider);
-            CreateTilemapObjForCells(source, sc.Edge,     settings[ShapeType_Hex.Edge],     HexEdgeObjName,  canAttachCollider);
-            CreateTilemapObjForCells(source, sc.Tip,      settings[ShapeType_Hex.Tip],      TipObjName,      canAttachCollider);
-            CreateTilemapObjForCells(source, sc.Isolate,  settings[ShapeType_Hex.Isolate],  IsolateObjName,  canAttachCollider);
+            CreateTilemapObjForCells(source, sc.Full,      settings[ShapeType_Hex.Full],      FullObjName,      canAttachCollider);
+            CreateTilemapObjForCells(source, sc.Junction5, settings[ShapeType_Hex.Junction5], Junction5ObjName, canAttachCollider);
+            CreateTilemapObjForCells(source, sc.Junction4, settings[ShapeType_Hex.Junction4], Junction4ObjName, canAttachCollider);
+            CreateTilemapObjForCells(source, sc.Junction3, settings[ShapeType_Hex.Junction3], Junction3ObjName, canAttachCollider);
+            CreateTilemapObjForCells(source, sc.Edge,      settings[ShapeType_Hex.Edge],      HexEdgeObjName,   canAttachCollider);
+            CreateTilemapObjForCells(source, sc.Tip,       settings[ShapeType_Hex.Tip],       TipObjName,       canAttachCollider);
+            CreateTilemapObjForCells(source, sc.Isolate,   settings[ShapeType_Hex.Isolate],   IsolateObjName,   canAttachCollider);
         }
 
         private static void CreateTilemapObjForCells(Tilemap source,
@@ -68,11 +70,11 @@ namespace TilemapSplitter
             if (cells == null || cells.Count == 0) return;
 
             //Skip instantiating this tile collection when the Independent flag is not enabled in settings
-            bool isRequiredIndependentFlag = name == CrossObjName   || name == TJunctionObjName ||
-                                             name == CornerObjName  || name == IsolateObjName   ||
-                                             name == FullObjName    || name == JunctionObjName  ||
-                                             name == HexCornerObjName || name == HexEdgeObjName ||
-                                             name == TipObjName;
+            bool isRequiredIndependentFlag = name == CrossObjName    || name == TJunctionObjName ||
+                                             name == CornerObjName   || name == IsolateObjName   ||
+                                             name == FullObjName     || name == Junction5ObjName ||
+                                             name == Junction4ObjName || name == Junction3ObjName ||
+                                             name == HexEdgeObjName  || name == TipObjName;
             if (isRequiredIndependentFlag &&
                 setting.flags.HasFlag(ShapeFlags.Independent) == false) return;
 

--- a/Packages/com.sunagimo.tilemapsplitter/Editor/TilemapPreviewDrawer.cs
+++ b/Packages/com.sunagimo.tilemapsplitter/Editor/TilemapPreviewDrawer.cs
@@ -42,21 +42,23 @@ namespace TilemapSplitter
 
             if (shapeSettings_Hex != null && hexShapeCells != null)
             {
-                var full     = shapeSettings_Hex[ShapeType_Hex.Full];
-                var junction = shapeSettings_Hex[ShapeType_Hex.Junction];
-                var co       = shapeSettings_Hex[ShapeType_Hex.Corner];
-                var edge     = shapeSettings_Hex[ShapeType_Hex.Edge];
-                var tip      = shapeSettings_Hex[ShapeType_Hex.Tip];
-                var i        = shapeSettings_Hex[ShapeType_Hex.Isolate];
+                var full      = shapeSettings_Hex[ShapeType_Hex.Full];
+                var j5        = shapeSettings_Hex[ShapeType_Hex.Junction5];
+                var j4        = shapeSettings_Hex[ShapeType_Hex.Junction4];
+                var j3        = shapeSettings_Hex[ShapeType_Hex.Junction3];
+                var edge      = shapeSettings_Hex[ShapeType_Hex.Edge];
+                var tip       = shapeSettings_Hex[ShapeType_Hex.Tip];
+                var i         = shapeSettings_Hex[ShapeType_Hex.Isolate];
 
                 var previewSettings = new (List<Vector3Int> cells, Color c, bool canPreview)[]
                 {
-                    (hexShapeCells.Full,     full.previewColor,     full.canPreview),
-                    (hexShapeCells.Junction, junction.previewColor, junction.canPreview),
-                    (hexShapeCells.Corner,   co.previewColor,   co.canPreview),
-                    (hexShapeCells.Edge,     edge.previewColor,     edge.canPreview),
-                    (hexShapeCells.Tip,      tip.previewColor,      tip.canPreview),
-                    (hexShapeCells.Isolate,  i.previewColor,  i.canPreview)
+                    (hexShapeCells.Full,      full.previewColor,      full.canPreview),
+                    (hexShapeCells.Junction5, j5.previewColor,        j5.canPreview),
+                    (hexShapeCells.Junction4, j4.previewColor,        j4.canPreview),
+                    (hexShapeCells.Junction3, j3.previewColor,        j3.canPreview),
+                    (hexShapeCells.Edge,      edge.previewColor,      edge.canPreview),
+                    (hexShapeCells.Tip,       tip.previewColor,       tip.canPreview),
+                    (hexShapeCells.Isolate,   i.previewColor,         i.canPreview)
                 };
                 foreach (var (cells, c, canPreview) in previewSettings)
                 {

--- a/Packages/com.sunagimo.tilemapsplitter/Editor/TilemapSplitterWindow.cs
+++ b/Packages/com.sunagimo.tilemapsplitter/Editor/TilemapSplitterWindow.cs
@@ -29,12 +29,13 @@ namespace TilemapSplitter
 
         private static Dictionary<ShapeType_Hex, ShapeSetting> CreateDefaultSettings_Hex() => new()
         {
-            [ShapeType_Hex.Full]     = new() { flags = ShapeFlags.Independent, previewColor = Color.red    },
-            [ShapeType_Hex.Junction] = new() { flags = ShapeFlags.Independent, previewColor = Color.blue   },
-            [ShapeType_Hex.Corner]   = new() { flags = ShapeFlags.Independent, previewColor = Color.cyan   },
-            [ShapeType_Hex.Edge]     = new() { flags = ShapeFlags.Independent, previewColor = Color.green  },
-            [ShapeType_Hex.Tip]      = new() { flags = ShapeFlags.Independent, previewColor = Color.yellow },
-            [ShapeType_Hex.Isolate]  = new() { flags = ShapeFlags.Independent, previewColor = Color.magenta },
+            [ShapeType_Hex.Full]      = new() { flags = ShapeFlags.Independent, previewColor = Color.red    },
+            [ShapeType_Hex.Junction5] = new() { flags = ShapeFlags.Independent, previewColor = Color.blue   },
+            [ShapeType_Hex.Junction4] = new() { flags = ShapeFlags.Independent, previewColor = Color.cyan   },
+            [ShapeType_Hex.Junction3] = new() { flags = ShapeFlags.Independent, previewColor = Color.green  },
+            [ShapeType_Hex.Edge]      = new() { flags = ShapeFlags.Independent, previewColor = Color.yellow },
+            [ShapeType_Hex.Tip]       = new() { flags = ShapeFlags.Independent, previewColor = Color.magenta },
+            [ShapeType_Hex.Isolate]   = new() { flags = ShapeFlags.Independent, previewColor = Color.gray   },
         };
 
         //For Rectangle or Isolate
@@ -46,8 +47,9 @@ namespace TilemapSplitter
         private Foldout isolateFoldOut;
         //For Hexagon
         private Foldout fullFoldOut;
-        private Foldout junctionFoldOut;
-        private Foldout hexCornerFoldOut;
+        private Foldout junction5FoldOut;
+        private Foldout junction4FoldOut;
+        private Foldout junction3FoldOut;
         private Foldout edgeFoldOut;
         private Foldout tipFoldOut;
         private Foldout hexIsolateFoldOut;
@@ -196,24 +198,26 @@ namespace TilemapSplitter
         {
             var infos = new (ShapeType_Hex type, string title)[]
             {
-                (ShapeType_Hex.Full,     "Full"),
-                (ShapeType_Hex.Junction, "Junction"),
-                (ShapeType_Hex.Corner,   "Corner"),
-                (ShapeType_Hex.Edge,     "Edge"),
-                (ShapeType_Hex.Tip,      "Tip"),
-                (ShapeType_Hex.Isolate,  "Isolate")
+                (ShapeType_Hex.Full,      "Full"),
+                (ShapeType_Hex.Junction5, "Junction5"),
+                (ShapeType_Hex.Junction4, "Junction4"),
+                (ShapeType_Hex.Junction3, "Junction3"),
+                (ShapeType_Hex.Edge,      "Edge"),
+                (ShapeType_Hex.Tip,       "Tip"),
+                (ShapeType_Hex.Isolate,   "Isolate")
             };
             foreach (var info in infos)
             {
                 var fold = CreateFoldout_Hex(container, info.type, info.title);
                 switch (info.type)
                 {
-                    case ShapeType_Hex.Full:     fullFoldOut       = fold; break;
-                    case ShapeType_Hex.Junction: junctionFoldOut   = fold; break;
-                    case ShapeType_Hex.Corner:   hexCornerFoldOut  = fold; break;
-                    case ShapeType_Hex.Edge:     edgeFoldOut       = fold; break;
-                    case ShapeType_Hex.Tip:      tipFoldOut        = fold; break;
-                    case ShapeType_Hex.Isolate:  hexIsolateFoldOut = fold; break;
+                    case ShapeType_Hex.Full:      fullFoldOut        = fold; break;
+                    case ShapeType_Hex.Junction5: junction5FoldOut   = fold; break;
+                    case ShapeType_Hex.Junction4: junction4FoldOut   = fold; break;
+                    case ShapeType_Hex.Junction3: junction3FoldOut   = fold; break;
+                    case ShapeType_Hex.Edge:      edgeFoldOut        = fold; break;
+                    case ShapeType_Hex.Tip:       tipFoldOut         = fold; break;
+                    case ShapeType_Hex.Isolate:   hexIsolateFoldOut  = fold; break;
                 }
                 AddHorizontalSeparator(container);
             }
@@ -431,12 +435,13 @@ namespace TilemapSplitter
             {
                 var list = new (Foldout f, string name, int count)[]
                 {
-                    (fullFoldOut,     "Full",     hexShapeCells.Full.Count),
-                    (junctionFoldOut, "Junction", hexShapeCells.Junction.Count),
-                    (hexCornerFoldOut,"Corner",   hexShapeCells.Corner.Count),
-                    (edgeFoldOut,     "Edge",     hexShapeCells.Edge.Count),
-                    (tipFoldOut,      "Tip",      hexShapeCells.Tip.Count),
-                    (hexIsolateFoldOut,"Isolate", hexShapeCells.Isolate.Count),
+                    (fullFoldOut,      "Full",      hexShapeCells.Full.Count),
+                    (junction5FoldOut, "Junction5", hexShapeCells.Junction5.Count),
+                    (junction4FoldOut, "Junction4", hexShapeCells.Junction4.Count),
+                    (junction3FoldOut, "Junction3", hexShapeCells.Junction3.Count),
+                    (edgeFoldOut,      "Edge",      hexShapeCells.Edge.Count),
+                    (tipFoldOut,       "Tip",       hexShapeCells.Tip.Count),
+                    (hexIsolateFoldOut,"Isolate",  hexShapeCells.Isolate.Count),
                 };
                 foreach (var (f, name, count) in list)
                 {

--- a/TilemapSplitter/TilemapSplitter/TileShapeClassifier.cs
+++ b/TilemapSplitter/TilemapSplitter/TileShapeClassifier.cs
@@ -27,12 +27,13 @@ namespace TilemapSplitter
 
     internal enum ShapeType_Hex
     {
-        Full = 0,
-        Junction,
-        Corner,
-        Edge,
+        Isolate = 0,
         Tip,
-        Isolate,
+        Edge,
+        Junction3,
+        Junction4,
+        Junction5,
+        Full,
     }
 
     internal class ShapeSetting
@@ -59,12 +60,13 @@ namespace TilemapSplitter
 
     internal class ShapeCells_Hex
     {
-        public readonly List<Vector3Int> Full     = new();
-        public readonly List<Vector3Int> Junction = new();
-        public readonly List<Vector3Int> Corner   = new();
-        public readonly List<Vector3Int> Edge     = new();
-        public readonly List<Vector3Int> Tip      = new();
-        public readonly List<Vector3Int> Isolate  = new();
+        public readonly List<Vector3Int> Isolate   = new();
+        public readonly List<Vector3Int> Tip       = new();
+        public readonly List<Vector3Int> Edge      = new();
+        public readonly List<Vector3Int> Junction3 = new();
+        public readonly List<Vector3Int> Junction4 = new();
+        public readonly List<Vector3Int> Junction5 = new();
+        public readonly List<Vector3Int> Full      = new();
     }
 
     internal static class TileShapeClassifier
@@ -211,12 +213,13 @@ namespace TilemapSplitter
         public static IEnumerator ClassifyCoroutine_Hex(Tilemap source,
             Dictionary<ShapeType_Hex, ShapeSetting> settings, ShapeCells_Hex sc, int batch = 100)
         {
-            sc.Full.Clear();
-            sc.Junction.Clear();
-            sc.Corner.Clear();
-            sc.Edge.Clear();
-            sc.Tip.Clear();
             sc.Isolate.Clear();
+            sc.Tip.Clear();
+            sc.Edge.Clear();
+            sc.Junction3.Clear();
+            sc.Junction4.Clear();
+            sc.Junction5.Clear();
+            sc.Full.Clear();
 
             source.CompressBounds();
 
@@ -347,41 +350,26 @@ namespace TilemapSplitter
         private static void Classify_Hex(Vector3Int cell, bool[] exist, int neighborCount,
             Dictionary<ShapeType_Hex, ShapeSetting> settings, ShapeCells_Hex sc)
         {
-            int mask = 0;
-            for (int i = 0; i < exist.Length; i++)
-            {
-                if (exist[i]) mask |= 1 << i;
-            }
-
             switch (neighborCount)
             {
                 case 6:
                     ApplyShapeFlags_Hex(cell, settings[ShapeType_Hex.Full].flags, sc, sc.Full);
                     break;
-
                 case 5:
+                    ApplyShapeFlags_Hex(cell, settings[ShapeType_Hex.Junction5].flags, sc, sc.Junction5);
+                    break;
                 case 4:
-                    ApplyShapeFlags_Hex(cell, settings[ShapeType_Hex.Junction].flags, sc, sc.Junction);
+                    ApplyShapeFlags_Hex(cell, settings[ShapeType_Hex.Junction4].flags, sc, sc.Junction4);
                     break;
-
                 case 3:
-                    if (HasConsecutiveBits(mask, 3))
-                        ApplyShapeFlags_Hex(cell, settings[ShapeType_Hex.Corner].flags, sc, sc.Corner);
-                    else
-                        ApplyShapeFlags_Hex(cell, settings[ShapeType_Hex.Junction].flags, sc, sc.Junction);
+                    ApplyShapeFlags_Hex(cell, settings[ShapeType_Hex.Junction3].flags, sc, sc.Junction3);
                     break;
-
                 case 2:
-                    if (IsOpposite(mask))
-                        ApplyShapeFlags_Hex(cell, settings[ShapeType_Hex.Edge].flags, sc, sc.Edge);
-                    else
-                        ApplyShapeFlags_Hex(cell, settings[ShapeType_Hex.Corner].flags, sc, sc.Corner);
+                    ApplyShapeFlags_Hex(cell, settings[ShapeType_Hex.Edge].flags, sc, sc.Edge);
                     break;
-
                 case 1:
                     ApplyShapeFlags_Hex(cell, settings[ShapeType_Hex.Tip].flags, sc, sc.Tip);
                     break;
-
                 default:
                     ApplyShapeFlags_Hex(cell, settings[ShapeType_Hex.Isolate].flags, sc, sc.Isolate);
                     break;

--- a/TilemapSplitter/TilemapSplitter/TilemapCreator.cs
+++ b/TilemapSplitter/TilemapSplitter/TilemapCreator.cs
@@ -16,11 +16,12 @@ namespace TilemapSplitter
         private const string CornerObjName     = "CornerTiles";
         private const string IsolateObjName    = "IsolateTiles";
         //For Hexagon
-        private const string FullObjName       = "FullTiles";
-        private const string JunctionObjName   = "JunctionTiles";
-        private const string HexCornerObjName  = "HexCornerTiles";
-        private const string HexEdgeObjName    = "HexEdgeTiles";
-        private const string TipObjName        = "TipTiles";
+        private const string FullObjName      = "FullTiles";
+        private const string Junction5ObjName = "Junction5Tiles";
+        private const string Junction4ObjName = "Junction4Tiles";
+        private const string Junction3ObjName = "Junction3Tiles";
+        private const string HexEdgeObjName   = "HexEdgeTiles";
+        private const string TipObjName       = "TipTiles";
 
         public static void GenerateSplitTilemaps_Rect(Tilemap source, ShapeCells_Rect sc,
             Dictionary<ShapeType_Rect, ShapeSetting> settings, bool mergeEdges, bool canAttachCollider)
@@ -54,12 +55,13 @@ namespace TilemapSplitter
         public static void GenerateSplitTilemaps_Hex(Tilemap source, ShapeCells_Hex sc,
             Dictionary<ShapeType_Hex, ShapeSetting> settings, bool canAttachCollider)
         {
-            CreateTilemapObjForCells(source, sc.Full,     settings[ShapeType_Hex.Full],     FullObjName,     canAttachCollider);
-            CreateTilemapObjForCells(source, sc.Junction, settings[ShapeType_Hex.Junction], JunctionObjName, canAttachCollider);
-            CreateTilemapObjForCells(source, sc.Corner,   settings[ShapeType_Hex.Corner],   HexCornerObjName,canAttachCollider);
-            CreateTilemapObjForCells(source, sc.Edge,     settings[ShapeType_Hex.Edge],     HexEdgeObjName,  canAttachCollider);
-            CreateTilemapObjForCells(source, sc.Tip,      settings[ShapeType_Hex.Tip],      TipObjName,      canAttachCollider);
-            CreateTilemapObjForCells(source, sc.Isolate,  settings[ShapeType_Hex.Isolate],  IsolateObjName,  canAttachCollider);
+            CreateTilemapObjForCells(source, sc.Full,      settings[ShapeType_Hex.Full],      FullObjName,      canAttachCollider);
+            CreateTilemapObjForCells(source, sc.Junction5, settings[ShapeType_Hex.Junction5], Junction5ObjName, canAttachCollider);
+            CreateTilemapObjForCells(source, sc.Junction4, settings[ShapeType_Hex.Junction4], Junction4ObjName, canAttachCollider);
+            CreateTilemapObjForCells(source, sc.Junction3, settings[ShapeType_Hex.Junction3], Junction3ObjName, canAttachCollider);
+            CreateTilemapObjForCells(source, sc.Edge,      settings[ShapeType_Hex.Edge],      HexEdgeObjName,   canAttachCollider);
+            CreateTilemapObjForCells(source, sc.Tip,       settings[ShapeType_Hex.Tip],       TipObjName,       canAttachCollider);
+            CreateTilemapObjForCells(source, sc.Isolate,   settings[ShapeType_Hex.Isolate],   IsolateObjName,   canAttachCollider);
         }
 
         private static void CreateTilemapObjForCells(Tilemap source,
@@ -68,11 +70,11 @@ namespace TilemapSplitter
             if (cells == null || cells.Count == 0) return;
 
             //Skip instantiating this tile collection when the Independent flag is not enabled in settings
-            bool isRequiredIndependentFlag = name == CrossObjName   || name == TJunctionObjName ||
-                                             name == CornerObjName  || name == IsolateObjName   ||
-                                             name == FullObjName    || name == JunctionObjName  ||
-                                             name == HexCornerObjName || name == HexEdgeObjName ||
-                                             name == TipObjName;
+            bool isRequiredIndependentFlag = name == CrossObjName    || name == TJunctionObjName ||
+                                             name == CornerObjName   || name == IsolateObjName   ||
+                                             name == FullObjName     || name == Junction5ObjName ||
+                                             name == Junction4ObjName || name == Junction3ObjName ||
+                                             name == HexEdgeObjName  || name == TipObjName;
             if (isRequiredIndependentFlag &&
                 setting.flags.HasFlag(ShapeFlags.Independent) == false) return;
 

--- a/TilemapSplitter/TilemapSplitter/TilemapPreviewDrawer.cs
+++ b/TilemapSplitter/TilemapSplitter/TilemapPreviewDrawer.cs
@@ -42,21 +42,23 @@ namespace TilemapSplitter
 
             if (shapeSettings_Hex != null && hexShapeCells != null)
             {
-                var full     = shapeSettings_Hex[ShapeType_Hex.Full];
-                var junction = shapeSettings_Hex[ShapeType_Hex.Junction];
-                var co       = shapeSettings_Hex[ShapeType_Hex.Corner];
-                var edge     = shapeSettings_Hex[ShapeType_Hex.Edge];
-                var tip      = shapeSettings_Hex[ShapeType_Hex.Tip];
-                var i        = shapeSettings_Hex[ShapeType_Hex.Isolate];
+                var full      = shapeSettings_Hex[ShapeType_Hex.Full];
+                var j5        = shapeSettings_Hex[ShapeType_Hex.Junction5];
+                var j4        = shapeSettings_Hex[ShapeType_Hex.Junction4];
+                var j3        = shapeSettings_Hex[ShapeType_Hex.Junction3];
+                var edge      = shapeSettings_Hex[ShapeType_Hex.Edge];
+                var tip       = shapeSettings_Hex[ShapeType_Hex.Tip];
+                var i         = shapeSettings_Hex[ShapeType_Hex.Isolate];
 
                 var previewSettings = new (List<Vector3Int> cells, Color c, bool canPreview)[]
                 {
-                    (hexShapeCells.Full,     full.previewColor,     full.canPreview),
-                    (hexShapeCells.Junction, junction.previewColor, junction.canPreview),
-                    (hexShapeCells.Corner,   co.previewColor,   co.canPreview),
-                    (hexShapeCells.Edge,     edge.previewColor,     edge.canPreview),
-                    (hexShapeCells.Tip,      tip.previewColor,      tip.canPreview),
-                    (hexShapeCells.Isolate,  i.previewColor,  i.canPreview)
+                    (hexShapeCells.Full,      full.previewColor,      full.canPreview),
+                    (hexShapeCells.Junction5, j5.previewColor,        j5.canPreview),
+                    (hexShapeCells.Junction4, j4.previewColor,        j4.canPreview),
+                    (hexShapeCells.Junction3, j3.previewColor,        j3.canPreview),
+                    (hexShapeCells.Edge,      edge.previewColor,      edge.canPreview),
+                    (hexShapeCells.Tip,       tip.previewColor,       tip.canPreview),
+                    (hexShapeCells.Isolate,   i.previewColor,         i.canPreview)
                 };
                 foreach (var (cells, c, canPreview) in previewSettings)
                 {

--- a/TilemapSplitter/TilemapSplitter/TilemapSplitterWindow.cs
+++ b/TilemapSplitter/TilemapSplitter/TilemapSplitterWindow.cs
@@ -29,12 +29,13 @@ namespace TilemapSplitter
 
         private static Dictionary<ShapeType_Hex, ShapeSetting> CreateDefaultSettings_Hex() => new()
         {
-            [ShapeType_Hex.Full]     = new() { flags = ShapeFlags.Independent, previewColor = Color.red    },
-            [ShapeType_Hex.Junction] = new() { flags = ShapeFlags.Independent, previewColor = Color.blue   },
-            [ShapeType_Hex.Corner]   = new() { flags = ShapeFlags.Independent, previewColor = Color.cyan   },
-            [ShapeType_Hex.Edge]     = new() { flags = ShapeFlags.Independent, previewColor = Color.green  },
-            [ShapeType_Hex.Tip]      = new() { flags = ShapeFlags.Independent, previewColor = Color.yellow },
-            [ShapeType_Hex.Isolate]  = new() { flags = ShapeFlags.Independent, previewColor = Color.magenta },
+            [ShapeType_Hex.Full]      = new() { flags = ShapeFlags.Independent, previewColor = Color.red    },
+            [ShapeType_Hex.Junction5] = new() { flags = ShapeFlags.Independent, previewColor = Color.blue   },
+            [ShapeType_Hex.Junction4] = new() { flags = ShapeFlags.Independent, previewColor = Color.cyan   },
+            [ShapeType_Hex.Junction3] = new() { flags = ShapeFlags.Independent, previewColor = Color.green  },
+            [ShapeType_Hex.Edge]      = new() { flags = ShapeFlags.Independent, previewColor = Color.yellow },
+            [ShapeType_Hex.Tip]       = new() { flags = ShapeFlags.Independent, previewColor = Color.magenta },
+            [ShapeType_Hex.Isolate]   = new() { flags = ShapeFlags.Independent, previewColor = Color.gray   },
         };
 
         //For Rectangle or Isolate
@@ -46,8 +47,9 @@ namespace TilemapSplitter
         private Foldout isolateFoldOut;
         //For Hexagon
         private Foldout fullFoldOut;
-        private Foldout junctionFoldOut;
-        private Foldout hexCornerFoldOut;
+        private Foldout junction5FoldOut;
+        private Foldout junction4FoldOut;
+        private Foldout junction3FoldOut;
         private Foldout edgeFoldOut;
         private Foldout tipFoldOut;
         private Foldout hexIsolateFoldOut;
@@ -196,24 +198,26 @@ namespace TilemapSplitter
         {
             var infos = new (ShapeType_Hex type, string title)[]
             {
-                (ShapeType_Hex.Full,     "Full"),
-                (ShapeType_Hex.Junction, "Junction"),
-                (ShapeType_Hex.Corner,   "Corner"),
-                (ShapeType_Hex.Edge,     "Edge"),
-                (ShapeType_Hex.Tip,      "Tip"),
-                (ShapeType_Hex.Isolate,  "Isolate")
+                (ShapeType_Hex.Full,      "Full"),
+                (ShapeType_Hex.Junction5, "Junction5"),
+                (ShapeType_Hex.Junction4, "Junction4"),
+                (ShapeType_Hex.Junction3, "Junction3"),
+                (ShapeType_Hex.Edge,      "Edge"),
+                (ShapeType_Hex.Tip,       "Tip"),
+                (ShapeType_Hex.Isolate,   "Isolate")
             };
             foreach (var info in infos)
             {
                 var fold = CreateFoldout_Hex(container, info.type, info.title);
                 switch (info.type)
                 {
-                    case ShapeType_Hex.Full:     fullFoldOut       = fold; break;
-                    case ShapeType_Hex.Junction: junctionFoldOut   = fold; break;
-                    case ShapeType_Hex.Corner:   hexCornerFoldOut  = fold; break;
-                    case ShapeType_Hex.Edge:     edgeFoldOut       = fold; break;
-                    case ShapeType_Hex.Tip:      tipFoldOut        = fold; break;
-                    case ShapeType_Hex.Isolate:  hexIsolateFoldOut = fold; break;
+                    case ShapeType_Hex.Full:      fullFoldOut        = fold; break;
+                    case ShapeType_Hex.Junction5: junction5FoldOut   = fold; break;
+                    case ShapeType_Hex.Junction4: junction4FoldOut   = fold; break;
+                    case ShapeType_Hex.Junction3: junction3FoldOut   = fold; break;
+                    case ShapeType_Hex.Edge:      edgeFoldOut        = fold; break;
+                    case ShapeType_Hex.Tip:       tipFoldOut         = fold; break;
+                    case ShapeType_Hex.Isolate:   hexIsolateFoldOut  = fold; break;
                 }
                 AddHorizontalSeparator(container);
             }
@@ -431,12 +435,13 @@ namespace TilemapSplitter
             {
                 var list = new (Foldout f, string name, int count)[]
                 {
-                    (fullFoldOut,     "Full",     hexShapeCells.Full.Count),
-                    (junctionFoldOut, "Junction", hexShapeCells.Junction.Count),
-                    (hexCornerFoldOut,"Corner",   hexShapeCells.Corner.Count),
-                    (edgeFoldOut,     "Edge",     hexShapeCells.Edge.Count),
-                    (tipFoldOut,      "Tip",      hexShapeCells.Tip.Count),
-                    (hexIsolateFoldOut,"Isolate", hexShapeCells.Isolate.Count),
+                    (fullFoldOut,      "Full",      hexShapeCells.Full.Count),
+                    (junction5FoldOut, "Junction5", hexShapeCells.Junction5.Count),
+                    (junction4FoldOut, "Junction4", hexShapeCells.Junction4.Count),
+                    (junction3FoldOut, "Junction3", hexShapeCells.Junction3.Count),
+                    (edgeFoldOut,      "Edge",      hexShapeCells.Edge.Count),
+                    (tipFoldOut,       "Tip",       hexShapeCells.Tip.Count),
+                    (hexIsolateFoldOut,"Isolate",  hexShapeCells.Isolate.Count),
                 };
                 foreach (var (f, name, count) in list)
                 {


### PR DESCRIPTION
## 概要
- 六角形タイルの分類を隣接数だけで判定するよう変更
- 分類タイプを `Isolate~Full` の7段階へ刷新
- それに伴うプレビュー表示・Tilemap生成処理を更新

## テスト
- `git status` で変更なしを確認

------
https://chatgpt.com/codex/tasks/task_e_68885aa24bb4832a883ca0ddad9a7513