### PR TITLE
Hexagon FlatTop プレビュー対応

### DIFF
--- a/Packages/com.sunagimo.tilemapsplitter/Editor/TilemapPreviewDrawer.cs
+++ b/Packages/com.sunagimo.tilemapsplitter/Editor/TilemapPreviewDrawer.cs
@@ -15,6 +15,7 @@ namespace TilemapSplitter
         private Dictionary<ShapeType_Hex, ShapeSetting>  shapeSettings_Hex;
         private ShapeCells_Rect shapeCells_Rect;
         private ShapeCells_Hex  shapeCells_Hex;
+        private bool            isPointTop = true;
 
         public void Setup_Rect(Tilemap source, Dictionary<ShapeType_Rect, ShapeSetting> settings)
         {
@@ -27,6 +28,14 @@ namespace TilemapSplitter
             tilemap            = source;
             shapeSettings_Hex  = settings;
             shapeSettings_Rect = null;
+            DetermineHexOrientation();
+        }
+
+        private void DetermineHexOrientation()
+        {
+            var center = tilemap.GetCellCenterWorld(Vector3Int.zero);
+            var right  = tilemap.GetCellCenterWorld(Vector3Int.right);
+            isPointTop = Mathf.Approximately(center.y, right.y);
         }
 
         public void SetShapeCells(ShapeCells_Rect sc) => shapeCells_Rect = sc;
@@ -135,9 +144,10 @@ namespace TilemapSplitter
                 Vector3 center  = tilemap.GetCellCenterWorld(cell);
                 Vector3[] verts = new Vector3[6];
 
+                float startDeg = isPointTop ? 30f : 0f;
                 for (int i = 0; i < 6; i++)
                 {
-                    float angleDeg = 60f * i + 30f;
+                    float angleDeg = 60f * i + startDeg;
                     float rad = Mathf.Deg2Rad * angleDeg;
                     verts[i] = new Vector3(center.x + halfW * Mathf.Cos(rad),
                         center.y + halfH * Mathf.Sin(rad),

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ TilemapSplitter is a Unity editor extension that automatically classifies tiles 
 - Categories like Cross can be merged into VerticalEdge or HorizontalEdge via `Which obj to add to`
 - After execution, new Tilemap objects are created per category
 - Enable preview to visualize classification results in the Scene
+- Hexagon layout preview supports both PointTop and FlatTop orientations
 - Settings persist via EditorPrefs even after closing the window
 - A reset button is available below the Split Tilemap field
 
@@ -113,6 +114,7 @@ Unity の `Tilemap` を接続関係に基づき自動で分類し、用途に応
   へ統合することもできる
 - 実行後、選択したカテゴリ別に新しい Tilemap オブジェクトを生成
 - プレビューを有効にすると Scene 上で分類結果をカラー表示
+- Hexagon レイアウトでは PointTop / FlatTop 双方のプレビューに対応
 - 設定は EditorPrefs を介して保存され、ウィンドウを閉じても維持
 - `Split Tilemap` 欄の下にリセットボタンを配置
 

--- a/TilemapSplitter/TilemapSplitter/TilemapPreviewDrawer.cs
+++ b/TilemapSplitter/TilemapSplitter/TilemapPreviewDrawer.cs
@@ -15,6 +15,7 @@ namespace TilemapSplitter
         private Dictionary<ShapeType_Hex, ShapeSetting>  shapeSettings_Hex;
         private ShapeCells_Rect shapeCells_Rect;
         private ShapeCells_Hex  shapeCells_Hex;
+        private bool            isPointTop = true;
 
         public void Setup_Rect(Tilemap source, Dictionary<ShapeType_Rect, ShapeSetting> settings)
         {
@@ -27,6 +28,14 @@ namespace TilemapSplitter
             tilemap            = source;
             shapeSettings_Hex  = settings;
             shapeSettings_Rect = null;
+            DetermineHexOrientation();
+        }
+
+        private void DetermineHexOrientation()
+        {
+            var center = tilemap.GetCellCenterWorld(Vector3Int.zero);
+            var right  = tilemap.GetCellCenterWorld(Vector3Int.right);
+            isPointTop = Mathf.Approximately(center.y, right.y);
         }
 
         public void SetShapeCells(ShapeCells_Rect sc) => shapeCells_Rect = sc;
@@ -135,9 +144,10 @@ namespace TilemapSplitter
                 Vector3 center  = tilemap.GetCellCenterWorld(cell);
                 Vector3[] verts = new Vector3[6];
 
+                float startDeg = isPointTop ? 30f : 0f;
                 for (int i = 0; i < 6; i++)
                 {
-                    float angleDeg = 60f * i + 30f;
+                    float angleDeg = 60f * i + startDeg;
                     float rad = Mathf.Deg2Rad * angleDeg;
                     verts[i] = new Vector3(center.x + halfW * Mathf.Cos(rad),
                         center.y + halfH * Mathf.Sin(rad),


### PR DESCRIPTION
## 概要
- Hexagon の PointTop / FlatTop を自動判別してプレビュー描画に反映
- README に Hexagon プレビュー対応を追記

## テスト
- `dotnet test` (コマンド未存在のため実行不可)
- `apt-get update` (リポジトリ署名エラーにより失敗)

------
https://chatgpt.com/codex/tasks/task_e_688f053ca0d8832a871329c198c18668