### PR TITLE
Rectレイアウト時のみEdge統合トグルを表示

### DIFF
--- a/Packages/com.sunagimo.tilemapsplitter/Editor/CellLayoutHandlers.cs
+++ b/Packages/com.sunagimo.tilemapsplitter/Editor/CellLayoutHandlers.cs
@@ -11,6 +11,7 @@ namespace TilemapSplitter
 {
     internal interface ILayoutHandler
     {
+        void CreateMergeEdgeToggle(VisualElement container, ref bool canMergeEdges);
         void CreateShapeFoldouts(VisualElement container);
         IEnumerator Classify(Tilemap source);
         void GenerateSplitTilemaps(Tilemap source, bool canMergeEdges, bool canAttachCollider);
@@ -34,8 +35,18 @@ namespace TilemapSplitter
 
         public RectLayoutHandler(Dictionary<ShapeType_Rect, ShapeSetting> settings, Action refreshPreview)
         {
-            settingsDict     = settings;
+            settingsDict       = settings;
             this.refreshPreview = refreshPreview;
+        }
+
+        public void CreateMergeEdgeToggle(VisualElement container, ref bool canMergeEdges)
+        {
+            var mergeT  = new Toggle("Merge VerticalEdge, HorizontalEdge") { value = canMergeEdges };
+            var mergeHB = new HelpBox("When merging, VerticalEdge shapeSettings_Rect take precedence",
+                HelpBoxMessageType.Info);
+            mergeT.RegisterValueChangedCallback(evt => canMergeEdges = evt.newValue);
+            container.Add(mergeT);
+            container.Add(mergeHB);
         }
 
         public void CreateShapeFoldouts(VisualElement container)
@@ -205,6 +216,10 @@ namespace TilemapSplitter
         {
             settingsDict = settings;
             this.refreshPreview = refreshPreview;
+        }
+
+        public void CreateMergeEdgeToggle(VisualElement container, ref bool canMergeEdges)
+        {
         }
 
         public void CreateShapeFoldouts(VisualElement container)

--- a/Packages/com.sunagimo.tilemapsplitter/Editor/TilemapSplitterWindow.cs
+++ b/Packages/com.sunagimo.tilemapsplitter/Editor/TilemapSplitterWindow.cs
@@ -68,7 +68,6 @@ namespace TilemapSplitter
             CreateSourceField(c);
             CreateResetButton(c);
             CreateColliderToggle(c);
-            CreateMergeEdgeToggle(c);
 
             if (source == null) return;
 
@@ -77,6 +76,7 @@ namespace TilemapSplitter
                 ? new HexLayoutHandler(settingsDict_hex, RefreshPreview)
                 : new RectLayoutHandler(settingsDict_rect, RefreshPreview);
 
+            layoutHandler.CreateMergeEdgeToggle(c, ref canMergeEdges);
             layoutHandler.CreateShapeFoldouts(c);
 
             CreateExecuteButton(c);
@@ -138,17 +138,6 @@ namespace TilemapSplitter
             attachT.value = canAttachCollider;
             attachT.RegisterValueChangedCallback(evt => canAttachCollider = evt.newValue);
             container.Add(attachT);
-        }
-
-        private void CreateMergeEdgeToggle(VisualElement container)
-        {
-            var mergeT  = new Toggle("Merge VerticalEdge, HorizontalEdge");
-            var mergeHB = new HelpBox("When merging, VerticalEdge shapeSettings_Rect take precedence",
-                HelpBoxMessageType.Info);
-            mergeT.value = canMergeEdges;
-            mergeT.RegisterValueChangedCallback(evt => canMergeEdges = evt.newValue);
-            container.Add(mergeT);
-            container.Add(mergeHB);
         }
 
         private void CreateExecuteButton(VisualElement container)

--- a/TilemapSplitter/TilemapSplitter/CellLayoutHandlers.cs
+++ b/TilemapSplitter/TilemapSplitter/CellLayoutHandlers.cs
@@ -11,6 +11,7 @@ namespace TilemapSplitter
 {
     internal interface ILayoutHandler
     {
+        void CreateMergeEdgeToggle(VisualElement container, ref bool canMergeEdges);
         void CreateShapeFoldouts(VisualElement container);
         IEnumerator Classify(Tilemap source);
         void GenerateSplitTilemaps(Tilemap source, bool canMergeEdges, bool canAttachCollider);
@@ -34,8 +35,18 @@ namespace TilemapSplitter
 
         public RectLayoutHandler(Dictionary<ShapeType_Rect, ShapeSetting> settings, Action refreshPreview)
         {
-            settingsDict     = settings;
+            settingsDict       = settings;
             this.refreshPreview = refreshPreview;
+        }
+
+        public void CreateMergeEdgeToggle(VisualElement container, ref bool canMergeEdges)
+        {
+            var mergeT  = new Toggle("Merge VerticalEdge, HorizontalEdge") { value = canMergeEdges };
+            var mergeHB = new HelpBox("When merging, VerticalEdge shapeSettings_Rect take precedence",
+                HelpBoxMessageType.Info);
+            mergeT.RegisterValueChangedCallback(evt => canMergeEdges = evt.newValue);
+            container.Add(mergeT);
+            container.Add(mergeHB);
         }
 
         public void CreateShapeFoldouts(VisualElement container)
@@ -205,6 +216,10 @@ namespace TilemapSplitter
         {
             settingsDict = settings;
             this.refreshPreview = refreshPreview;
+        }
+
+        public void CreateMergeEdgeToggle(VisualElement container, ref bool canMergeEdges)
+        {
         }
 
         public void CreateShapeFoldouts(VisualElement container)

--- a/TilemapSplitter/TilemapSplitter/TilemapSplitterWindow.cs
+++ b/TilemapSplitter/TilemapSplitter/TilemapSplitterWindow.cs
@@ -68,7 +68,6 @@ namespace TilemapSplitter
             CreateSourceField(c);
             CreateResetButton(c);
             CreateColliderToggle(c);
-            CreateMergeEdgeToggle(c);
 
             if (source == null) return;
 
@@ -77,6 +76,7 @@ namespace TilemapSplitter
                 ? new HexLayoutHandler(settingsDict_hex, RefreshPreview)
                 : new RectLayoutHandler(settingsDict_rect, RefreshPreview);
 
+            layoutHandler.CreateMergeEdgeToggle(c, ref canMergeEdges);
             layoutHandler.CreateShapeFoldouts(c);
 
             CreateExecuteButton(c);
@@ -138,17 +138,6 @@ namespace TilemapSplitter
             attachT.value = canAttachCollider;
             attachT.RegisterValueChangedCallback(evt => canAttachCollider = evt.newValue);
             container.Add(attachT);
-        }
-
-        private void CreateMergeEdgeToggle(VisualElement container)
-        {
-            var mergeT  = new Toggle("Merge VerticalEdge, HorizontalEdge");
-            var mergeHB = new HelpBox("When merging, VerticalEdge shapeSettings_Rect take precedence",
-                HelpBoxMessageType.Info);
-            mergeT.value = canMergeEdges;
-            mergeT.RegisterValueChangedCallback(evt => canMergeEdges = evt.newValue);
-            container.Add(mergeT);
-            container.Add(mergeHB);
         }
 
         private void CreateExecuteButton(VisualElement container)


### PR DESCRIPTION
## 概要
- Merge Edge トグルを Rect レイアウト専用 GUI として CellLayoutHandler へ移動
- Hex レイアウトでは Edge 統合トグルを生成しないよう対応

## テスト
- `dotnet test` 実行 (dotnet が存在せず未実行)


------
https://chatgpt.com/codex/tasks/task_e_688f36349120832a85461dad87a609e7