### PR TITLE
ref引数を用いるトグル生成処理をgetter/setterに置換

### DIFF
--- a/Packages/com.sunagimo.tilemapsplitter/Editor/CellLayoutHandlers.cs
+++ b/Packages/com.sunagimo.tilemapsplitter/Editor/CellLayoutHandlers.cs
@@ -11,7 +11,7 @@ namespace TilemapSplitter
 {
     internal interface ILayoutHandler
     {
-        void CreateMergeEdgeToggle(VisualElement container, ref bool canMergeEdges);
+        void CreateMergeEdgeToggle(VisualElement container, Func<bool> getter, Action<bool> setter);
         void CreateShapeFoldouts(VisualElement container);
         IEnumerator Classify(Tilemap source);
         void GenerateSplitTilemaps(Tilemap source, bool canMergeEdges, bool canAttachCollider);
@@ -39,12 +39,12 @@ namespace TilemapSplitter
             this.refreshPreview = refreshPreview;
         }
 
-        public void CreateMergeEdgeToggle(VisualElement container, ref bool canMergeEdges)
+        public void CreateMergeEdgeToggle(VisualElement container, Func<bool> getter, Action<bool> setter)
         {
-            var mergeT  = new Toggle("Merge VerticalEdge, HorizontalEdge") { value = canMergeEdges };
+            var mergeT  = new Toggle("Merge VerticalEdge, HorizontalEdge") { value = getter() };
             var mergeHB = new HelpBox("When merging, VerticalEdge shapeSettings_Rect take precedence",
                 HelpBoxMessageType.Info);
-            mergeT.RegisterValueChangedCallback(evt => canMergeEdges = evt.newValue);
+            mergeT.RegisterValueChangedCallback(evt => setter(evt.newValue));
             container.Add(mergeT);
             container.Add(mergeHB);
         }
@@ -218,7 +218,7 @@ namespace TilemapSplitter
             this.refreshPreview = refreshPreview;
         }
 
-        public void CreateMergeEdgeToggle(VisualElement container, ref bool canMergeEdges)
+        public void CreateMergeEdgeToggle(VisualElement container, Func<bool> getter, Action<bool> setter)
         {
         }
 

--- a/Packages/com.sunagimo.tilemapsplitter/Editor/TilemapSplitterWindow.cs
+++ b/Packages/com.sunagimo.tilemapsplitter/Editor/TilemapSplitterWindow.cs
@@ -76,7 +76,7 @@ namespace TilemapSplitter
                 ? new HexLayoutHandler(settingsDict_hex, RefreshPreview)
                 : new RectLayoutHandler(settingsDict_rect, RefreshPreview);
 
-            layoutHandler.CreateMergeEdgeToggle(c, ref canMergeEdges);
+            layoutHandler.CreateMergeEdgeToggle(c, () => canMergeEdges, v => canMergeEdges = v);
             layoutHandler.CreateShapeFoldouts(c);
 
             CreateExecuteButton(c);

--- a/TilemapSplitter/TilemapSplitter/CellLayoutHandlers.cs
+++ b/TilemapSplitter/TilemapSplitter/CellLayoutHandlers.cs
@@ -11,7 +11,7 @@ namespace TilemapSplitter
 {
     internal interface ILayoutHandler
     {
-        void CreateMergeEdgeToggle(VisualElement container, ref bool canMergeEdges);
+        void CreateMergeEdgeToggle(VisualElement container, Func<bool> getter, Action<bool> setter);
         void CreateShapeFoldouts(VisualElement container);
         IEnumerator Classify(Tilemap source);
         void GenerateSplitTilemaps(Tilemap source, bool canMergeEdges, bool canAttachCollider);
@@ -39,12 +39,12 @@ namespace TilemapSplitter
             this.refreshPreview = refreshPreview;
         }
 
-        public void CreateMergeEdgeToggle(VisualElement container, ref bool canMergeEdges)
+        public void CreateMergeEdgeToggle(VisualElement container, Func<bool> getter, Action<bool> setter)
         {
-            var mergeT  = new Toggle("Merge VerticalEdge, HorizontalEdge") { value = canMergeEdges };
+            var mergeT  = new Toggle("Merge VerticalEdge, HorizontalEdge") { value = getter() };
             var mergeHB = new HelpBox("When merging, VerticalEdge shapeSettings_Rect take precedence",
                 HelpBoxMessageType.Info);
-            mergeT.RegisterValueChangedCallback(evt => canMergeEdges = evt.newValue);
+            mergeT.RegisterValueChangedCallback(evt => setter(evt.newValue));
             container.Add(mergeT);
             container.Add(mergeHB);
         }
@@ -218,7 +218,7 @@ namespace TilemapSplitter
             this.refreshPreview = refreshPreview;
         }
 
-        public void CreateMergeEdgeToggle(VisualElement container, ref bool canMergeEdges)
+        public void CreateMergeEdgeToggle(VisualElement container, Func<bool> getter, Action<bool> setter)
         {
         }
 

--- a/TilemapSplitter/TilemapSplitter/TilemapSplitterWindow.cs
+++ b/TilemapSplitter/TilemapSplitter/TilemapSplitterWindow.cs
@@ -76,7 +76,7 @@ namespace TilemapSplitter
                 ? new HexLayoutHandler(settingsDict_hex, RefreshPreview)
                 : new RectLayoutHandler(settingsDict_rect, RefreshPreview);
 
-            layoutHandler.CreateMergeEdgeToggle(c, ref canMergeEdges);
+            layoutHandler.CreateMergeEdgeToggle(c, () => canMergeEdges, v => canMergeEdges = v);
             layoutHandler.CreateShapeFoldouts(c);
 
             CreateExecuteButton(c);


### PR DESCRIPTION
## 概要
- CreateMergeEdgeToggleのref bool引数をgetter/setterに変更
- トグル値の更新方式をラムダによる安全な代入へ移行
- Window側の呼び出しとパッケージ版コードを同様に修正

## テスト
- `dotnet build` (コマンド未存在)
- `apt-get update` (403 Forbiddenにより失敗)


------
https://chatgpt.com/codex/tasks/task_e_688f3c608284832abe50c44f135d8118