### PR TITLE
プログレスバーのキャンセル処理を呼び出し元に伝播

### DIFF
--- a/Packages/com.sunagimo.tilemapsplitter/Editor/CellLayoutStrategies.cs
+++ b/Packages/com.sunagimo.tilemapsplitter/Editor/CellLayoutStrategies.cs
@@ -16,7 +16,7 @@ namespace TilemapSplitter
     {
         void CreateMergeEdgeToggle(VisualElement container, Func<bool> getter, Action<bool> setter);
         void CreateShapeFoldouts(VisualElement container);
-        IEnumerator Classify(Tilemap source);
+        IEnumerator<bool> Classify(Tilemap source);
         void GenerateSplitTilemaps(Tilemap source, bool canMergeEdges, bool canAttachCollider);
         void SetupPreview(Tilemap source, TilemapPreviewDrawer drawer);
         void SetShapeCellsToPreview(TilemapPreviewDrawer drawer);
@@ -165,7 +165,7 @@ namespace TilemapSplitter
             colField.visible      = isVisible;
         }
 
-        public IEnumerator Classify(Tilemap source)
+        public IEnumerator<bool> Classify(Tilemap source)
         {
             shapeCells = new ShapeCells_Rect();
             return TileShapeClassifier.ClassifyCoroutine_Rect(source, settingsDict, shapeCells);
@@ -294,7 +294,7 @@ namespace TilemapSplitter
             fold.Add(colF);
         }
 
-        public IEnumerator Classify(Tilemap source)
+        public IEnumerator<bool> Classify(Tilemap source)
         {
             shapeCells = new ShapeCells_Hex();
             return TileShapeClassifier.ClassifyCoroutine_Hex(source, settingsDict, shapeCells);

--- a/Packages/com.sunagimo.tilemapsplitter/Editor/TileShapeClassifier.cs
+++ b/Packages/com.sunagimo.tilemapsplitter/Editor/TileShapeClassifier.cs
@@ -127,12 +127,12 @@ namespace TilemapSplitter
             return occupiedCells;
         }
 
-        private static IEnumerator ProcessCells(HashSet<Vector3Int> occupiedCells, int batch, string progressTitle, Action<Vector3Int> perCell)
+        private static IEnumerator<bool> ProcessCells(HashSet<Vector3Int> occupiedCells, int batch, string progressTitle, Action<Vector3Int> perCell)
         {
             bool isCancelled = false;
             try
             {
-                int total = occupiedCells.Count;
+                int total     = occupiedCells.Count;
                 int processed = 0;
                 foreach (var cell in occupiedCells)
                 {
@@ -142,14 +142,16 @@ namespace TilemapSplitter
                     if (processed % batch == 0)
                     {
                         float progress = (float)processed / total;
-                        isCancelled = EditorUtility.DisplayCancelableProgressBar(progressTitle,
-                            $"Classifying... {processed}/{total}", progress);
-                        if (isCancelled) break;
-
-                        yield return null;
+                        isCancelled = EditorUtility.DisplayCancelableProgressBar(
+                            progressTitle,
+                            $"Classifying... {processed}/{total}",
+                            progress);
+                        yield return isCancelled;
+                        if (isCancelled) yield break;
                     }
                 }
-                if (isCancelled) yield break;
+
+                yield return false;
             }
             finally
             {
@@ -160,7 +162,7 @@ namespace TilemapSplitter
         /// <summary>
         /// Compress the tilemap bounds to exclude empty rows and columns
         /// </summary>
-        public static IEnumerator ClassifyCoroutine_Rect(Tilemap source,
+        public static IEnumerator<bool> ClassifyCoroutine_Rect(Tilemap source,
             Dictionary<ShapeType_Rect, ShapeSetting> settings, ShapeCells_Rect sc, int batch = 100)
         {
             sc.Vertical.Clear();
@@ -175,11 +177,11 @@ namespace TilemapSplitter
                 cell => Classify_Rect(cell, occupiedCells, settings, sc));
             while (e.MoveNext())
             {
-                yield return null;
+                yield return e.Current;
             }
         }
 
-        public static IEnumerator ClassifyCoroutine_Hex(Tilemap source,
+        public static IEnumerator<bool> ClassifyCoroutine_Hex(Tilemap source,
             Dictionary<ShapeType_Hex, ShapeSetting> settings, ShapeCells_Hex sc, int batch = 100)
         {
             sc.Isolate.Clear();
@@ -205,7 +207,7 @@ namespace TilemapSplitter
 
             while (e.MoveNext())
             {
-                yield return null;
+                yield return e.Current;
             }
         }
 

--- a/Packages/com.sunagimo.tilemapsplitter/Editor/TilemapSplitterWindow.cs
+++ b/Packages/com.sunagimo.tilemapsplitter/Editor/TilemapSplitterWindow.cs
@@ -181,8 +181,12 @@ namespace TilemapSplitter
 
         private IEnumerator SplitCoroutine()
         {
-            IEnumerator e = layoutStrategy.Classify(source);
-            while (e.MoveNext()) yield return null;
+            IEnumerator<bool> e = layoutStrategy.Classify(source);
+            while (e.MoveNext())
+            {
+                if (e.Current) yield break;
+                yield return null;
+            }
             layoutStrategy.GenerateSplitTilemaps(source, canMergeEdges, canAttachCollider);
             RefreshPreview();
         }
@@ -196,9 +200,14 @@ namespace TilemapSplitter
             {
                 isRefreshingPreview = true;
 
-                IEnumerator e = layoutStrategy.Classify(source);
+                IEnumerator<bool> e = layoutStrategy.Classify(source);
                 while (e.MoveNext())
                 {
+                    if (e.Current)
+                    {
+                        isRefreshingPreview = false;
+                        yield break;
+                    }
                     yield return null;
                 }
 

--- a/TilemapSplitter/TilemapSplitter/CellLayoutStrategies.cs
+++ b/TilemapSplitter/TilemapSplitter/CellLayoutStrategies.cs
@@ -16,7 +16,7 @@ namespace TilemapSplitter
     {
         void CreateMergeEdgeToggle(VisualElement container, Func<bool> getter, Action<bool> setter);
         void CreateShapeFoldouts(VisualElement container);
-        IEnumerator Classify(Tilemap source);
+        IEnumerator<bool> Classify(Tilemap source);
         void GenerateSplitTilemaps(Tilemap source, bool canMergeEdges, bool canAttachCollider);
         void SetupPreview(Tilemap source, TilemapPreviewDrawer drawer);
         void SetShapeCellsToPreview(TilemapPreviewDrawer drawer);
@@ -165,7 +165,7 @@ namespace TilemapSplitter
             colField.visible      = isVisible;
         }
 
-        public IEnumerator Classify(Tilemap source)
+        public IEnumerator<bool> Classify(Tilemap source)
         {
             shapeCells = new ShapeCells_Rect();
             return TileShapeClassifier.ClassifyCoroutine_Rect(source, settingsDict, shapeCells);
@@ -294,7 +294,7 @@ namespace TilemapSplitter
             fold.Add(colF);
         }
 
-        public IEnumerator Classify(Tilemap source)
+        public IEnumerator<bool> Classify(Tilemap source)
         {
             shapeCells = new ShapeCells_Hex();
             return TileShapeClassifier.ClassifyCoroutine_Hex(source, settingsDict, shapeCells);

--- a/TilemapSplitter/TilemapSplitter/TileShapeClassifier.cs
+++ b/TilemapSplitter/TilemapSplitter/TileShapeClassifier.cs
@@ -127,12 +127,12 @@ namespace TilemapSplitter
             return occupiedCells;
         }
 
-        private static IEnumerator ProcessCells(HashSet<Vector3Int> occupiedCells, int batch, string progressTitle, Action<Vector3Int> perCell)
+        private static IEnumerator<bool> ProcessCells(HashSet<Vector3Int> occupiedCells, int batch, string progressTitle, Action<Vector3Int> perCell)
         {
             bool isCancelled = false;
             try
             {
-                int total = occupiedCells.Count;
+                int total     = occupiedCells.Count;
                 int processed = 0;
                 foreach (var cell in occupiedCells)
                 {
@@ -142,14 +142,16 @@ namespace TilemapSplitter
                     if (processed % batch == 0)
                     {
                         float progress = (float)processed / total;
-                        isCancelled = EditorUtility.DisplayCancelableProgressBar(progressTitle,
-                            $"Classifying... {processed}/{total}", progress);
-                        if (isCancelled) break;
-
-                        yield return null;
+                        isCancelled = EditorUtility.DisplayCancelableProgressBar(
+                            progressTitle,
+                            $"Classifying... {processed}/{total}",
+                            progress);
+                        yield return isCancelled;
+                        if (isCancelled) yield break;
                     }
                 }
-                if (isCancelled) yield break;
+
+                yield return false;
             }
             finally
             {
@@ -160,7 +162,7 @@ namespace TilemapSplitter
         /// <summary>
         /// Compress the tilemap bounds to exclude empty rows and columns
         /// </summary>
-        public static IEnumerator ClassifyCoroutine_Rect(Tilemap source,
+        public static IEnumerator<bool> ClassifyCoroutine_Rect(Tilemap source,
             Dictionary<ShapeType_Rect, ShapeSetting> settings, ShapeCells_Rect sc, int batch = 100)
         {
             sc.Vertical.Clear();
@@ -175,11 +177,11 @@ namespace TilemapSplitter
                 cell => Classify_Rect(cell, occupiedCells, settings, sc));
             while (e.MoveNext())
             {
-                yield return null;
+                yield return e.Current;
             }
         }
 
-        public static IEnumerator ClassifyCoroutine_Hex(Tilemap source,
+        public static IEnumerator<bool> ClassifyCoroutine_Hex(Tilemap source,
             Dictionary<ShapeType_Hex, ShapeSetting> settings, ShapeCells_Hex sc, int batch = 100)
         {
             sc.Isolate.Clear();
@@ -205,7 +207,7 @@ namespace TilemapSplitter
 
             while (e.MoveNext())
             {
-                yield return null;
+                yield return e.Current;
             }
         }
 

--- a/TilemapSplitter/TilemapSplitter/TilemapSplitterWindow.cs
+++ b/TilemapSplitter/TilemapSplitter/TilemapSplitterWindow.cs
@@ -181,8 +181,12 @@ namespace TilemapSplitter
 
         private IEnumerator SplitCoroutine()
         {
-            IEnumerator e = layoutStrategy.Classify(source);
-            while (e.MoveNext()) yield return null;
+            IEnumerator<bool> e = layoutStrategy.Classify(source);
+            while (e.MoveNext())
+            {
+                if (e.Current) yield break;
+                yield return null;
+            }
             layoutStrategy.GenerateSplitTilemaps(source, canMergeEdges, canAttachCollider);
             RefreshPreview();
         }
@@ -196,9 +200,14 @@ namespace TilemapSplitter
             {
                 isRefreshingPreview = true;
 
-                IEnumerator e = layoutStrategy.Classify(source);
+                IEnumerator<bool> e = layoutStrategy.Classify(source);
                 while (e.MoveNext())
                 {
+                    if (e.Current)
+                    {
+                        isRefreshingPreview = false;
+                        yield break;
+                    }
                     yield return null;
                 }
 


### PR DESCRIPTION
## 概要
- プログレスバーのキャンセル状態を呼び出し元に返すよう修正
- 分割処理およびプレビュー更新でキャンセルを検知し中断するよう変更

## テスト
- `dotnet test`（dotnet 未インストールのため失敗）
- `apt-get update`（403 Forbidden のため失敗）

------
https://chatgpt.com/codex/tasks/task_e_6892166dbe4c832a811ff4d52f7fd2f4