### PR TITLE
EditorCoroutineUtility導入によるコルーチン処理の簡潔化

### DIFF
--- a/Packages/com.sunagimo.tilemapsplitter/Editor/TilemapSplitterWindow.cs
+++ b/Packages/com.sunagimo.tilemapsplitter/Editor/TilemapSplitterWindow.cs
@@ -5,6 +5,7 @@ namespace TilemapSplitter
     using System.Collections.Generic;
     using UnityEditor;
     using UnityEditor.UIElements;
+    using Unity.EditorCoroutines.Editor;
     using UnityEngine;
     using UnityEngine.Tilemaps;
     using UnityEngine.UIElements;
@@ -153,7 +154,7 @@ namespace TilemapSplitter
                     EditorUtility.DisplayDialog("Error", "The split target isn't set", "OK");
                     return;
                 }
-                StartCoroutine(SplitCoroutine());
+                EditorCoroutineUtility.StartCoroutine(SplitCoroutine(), this);
             });
             splitB.text            = "Execute Splitting";
             splitB.style.marginTop = 10;
@@ -168,16 +169,6 @@ namespace TilemapSplitter
             separator.style.marginTop         = 5;
             separator.style.marginBottom      = 5;
             parentContainer.Add(separator);
-        }
-
-        private static void StartCoroutine(IEnumerator e)
-        {
-            EditorApplication.update += Update;
-
-            void Update()
-            {
-                if (e.MoveNext() == false) EditorApplication.update -= Update;
-            }
         }
 
         private IEnumerator SplitCoroutine()
@@ -195,7 +186,7 @@ namespace TilemapSplitter
         private void RefreshPreview()
         {
             if (source == null || isRefreshingPreview || layoutStrategy == null) return;
-            StartCoroutine(RefreshPreviewCoroutine());
+            EditorCoroutineUtility.StartCoroutine(RefreshPreviewCoroutine(), this);
 
             IEnumerator RefreshPreviewCoroutine()
             {

--- a/Packages/com.sunagimo.tilemapsplitter/package.json
+++ b/Packages/com.sunagimo.tilemapsplitter/package.json
@@ -8,5 +8,8 @@
         "name": "Fukada_Ryuto",
         "url": "https://github.com/SunagimoOisii"
     },
-    "license": "MIT"
+    "license": "MIT",
+    "dependencies": {
+        "com.unity.editorcoroutines": "1.0.0"
+    }
 }

--- a/TilemapSplitter/TilemapSplitter/TilemapSplitterWindow.cs
+++ b/TilemapSplitter/TilemapSplitter/TilemapSplitterWindow.cs
@@ -5,6 +5,7 @@ namespace TilemapSplitter
     using System.Collections.Generic;
     using UnityEditor;
     using UnityEditor.UIElements;
+    using Unity.EditorCoroutines.Editor;
     using UnityEngine;
     using UnityEngine.Tilemaps;
     using UnityEngine.UIElements;
@@ -153,7 +154,7 @@ namespace TilemapSplitter
                     EditorUtility.DisplayDialog("Error", "The split target isn't set", "OK");
                     return;
                 }
-                StartCoroutine(SplitCoroutine());
+                EditorCoroutineUtility.StartCoroutine(SplitCoroutine(), this);
             });
             splitB.text            = "Execute Splitting";
             splitB.style.marginTop = 10;
@@ -168,16 +169,6 @@ namespace TilemapSplitter
             separator.style.marginTop         = 5;
             separator.style.marginBottom      = 5;
             parentContainer.Add(separator);
-        }
-
-        private static void StartCoroutine(IEnumerator e)
-        {
-            EditorApplication.update += Update;
-
-            void Update()
-            {
-                if (e.MoveNext() == false) EditorApplication.update -= Update;
-            }
         }
 
         private IEnumerator SplitCoroutine()
@@ -195,7 +186,7 @@ namespace TilemapSplitter
         private void RefreshPreview()
         {
             if (source == null || isRefreshingPreview || layoutStrategy == null) return;
-            StartCoroutine(RefreshPreviewCoroutine());
+            EditorCoroutineUtility.StartCoroutine(RefreshPreviewCoroutine(), this);
 
             IEnumerator RefreshPreviewCoroutine()
             {


### PR DESCRIPTION
## 概要
- EditorCoroutineUtilityに置き換え、EditorApplication.updateベースの独自コルーチンを削除
- パッケージに`com.unity.editorcoroutines`依存を追加

## テスト
- `dotnet build`：`command not found`により失敗
- `apt-get update`：403 Forbiddenにより依存取得失敗

------
https://chatgpt.com/codex/tasks/task_e_6892fbe35860832a855089763525b81f