### PR TITLE
進捗通知API導入による分類処理の独立化

### DIFF
--- a/Packages/com.sunagimo.tilemapsplitter/Editor/CellLayoutStrategy_Hex.cs
+++ b/Packages/com.sunagimo.tilemapsplitter/Editor/CellLayoutStrategy_Hex.cs
@@ -97,10 +97,11 @@ namespace TilemapSplitter
             fold.Add(colF);
         }
 
-        public IEnumerator<bool> Classify(Tilemap source)
+        public IEnumerator<bool> Classify(Tilemap source, IProgress<float> progress = null,
+            Func<bool> isCancelled = null)
         {
             shapeCells = new ShapeCells_Hex();
-            return TileShapeClassifier.ClassifyCoroutine(source, settingsDict, shapeCells);
+            return TileShapeClassifier.ClassifyCoroutine(source, settingsDict, shapeCells, 100, progress, isCancelled);
         }
 
         public void GenerateSplitTilemaps(Tilemap source, bool canMergeEdges, bool canAttachCollider)

--- a/Packages/com.sunagimo.tilemapsplitter/Editor/CellLayoutStrategy_Rect.cs
+++ b/Packages/com.sunagimo.tilemapsplitter/Editor/CellLayoutStrategy_Rect.cs
@@ -146,10 +146,11 @@ namespace TilemapSplitter
             colField.visible      = isVisible;
         }
 
-        public IEnumerator<bool> Classify(Tilemap source)
+        public IEnumerator<bool> Classify(Tilemap source, IProgress<float> progress = null,
+            Func<bool> isCancelled = null)
         {
             shapeCells = new ShapeCells_Rect();
-            return TileShapeClassifier.ClassifyCoroutine(source, settingsDict, shapeCells);
+            return TileShapeClassifier.ClassifyCoroutine(source, settingsDict, shapeCells, 100, progress, isCancelled);
         }
 
         public void GenerateSplitTilemaps(Tilemap source, bool canMergeEdges, bool canAttachCollider)

--- a/Packages/com.sunagimo.tilemapsplitter/Editor/ICellLayoutStrategy.cs
+++ b/Packages/com.sunagimo.tilemapsplitter/Editor/ICellLayoutStrategy.cs
@@ -6,13 +6,14 @@ namespace TilemapSplitter
     using UnityEngine.UIElements;
 
     /// <summary>
-    /// Strategy interface that provides processing based on cell layout
+    /// Strategy interface that provides operations according to cell layout
     /// </summary>
     internal interface ICellLayoutStrategy
     {
         void CreateMergeEdgeToggle(VisualElement container, Func<bool> getter, Action<bool> setter);
         void CreateShapeFoldouts(VisualElement container);
-        IEnumerator<bool> Classify(Tilemap source);
+        IEnumerator<bool> Classify(Tilemap source, IProgress<float> progress = null,
+            Func<bool> isCancelled = null);
         void GenerateSplitTilemaps(Tilemap source, bool canMergeEdges, bool canAttachCollider);
         void SetupPreview(Tilemap source, TilemapPreviewDrawer drawer);
         void SetShapeCellsToPreview(TilemapPreviewDrawer drawer);


### PR DESCRIPTION
## 概要
- `TileShapeClassifier` を `EditorUtility` 非依存に改修し、`IProgress<float>` とキャンセルコールバックを受け取るよう変更
- 分類処理を呼び出す各ストラテジー・ウィンドウから進捗バーを注入する設計へ
- コードコメントを英語へ翻訳

## テスト
- `dotnet build`（`dotnet` が存在せず失敗）
- `apt-get update`（403 Forbidden により失敗）

------
https://chatgpt.com/codex/tasks/task_e_689359703234832aaa58fdb4f032b405