### PR TITLE
設定保存とUI・サービス分離のリファクタリング

### DIFF
--- a/Packages/com.sunagimo.tilemapsplitter/Editor/TilemapSplitSettings.cs
+++ b/Packages/com.sunagimo.tilemapsplitter/Editor/TilemapSplitSettings.cs
@@ -1,0 +1,17 @@
+namespace TilemapSplitter
+{
+    using System.Collections.Generic;
+    using UnityEngine.Tilemaps;
+
+    /// <summary>
+    /// 分割設定データ
+    /// </summary>
+    internal class TilemapSplitSettings
+    {
+        public Tilemap source;
+        public bool canMergeEdges;
+        public bool canAttachCollider;
+        public Dictionary<ShapeType_Rect, ShapeSetting> rectSettings;
+        public Dictionary<ShapeType_Hex, ShapeSetting> hexSettings;
+    }
+}

--- a/Packages/com.sunagimo.tilemapsplitter/Editor/TilemapSplitSettings.cs.meta
+++ b/Packages/com.sunagimo.tilemapsplitter/Editor/TilemapSplitSettings.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 265316bbd1df4751ab7e2e10d847bf59

--- a/Packages/com.sunagimo.tilemapsplitter/Editor/TilemapSplitSettingsRepository.cs
+++ b/Packages/com.sunagimo.tilemapsplitter/Editor/TilemapSplitSettingsRepository.cs
@@ -1,0 +1,173 @@
+namespace TilemapSplitter
+{
+    using System;
+    using System.Collections.Generic;
+    using UnityEditor;
+    using UnityEngine;
+    using UnityEngine.Tilemaps;
+
+    /// <summary>
+    /// EditorPrefs を利用した設定保存クラス
+    /// </summary>
+    internal class TilemapSplitSettingsRepository
+    {
+        private const string PrefPrefix = "TilemapSplitter.";
+        private static string CreateKey(string name) => PrefPrefix + name;
+
+        public TilemapSplitSettings Load()
+        {
+            var data = new TilemapSplitSettings
+            {
+                rectSettings = CreateDefaultSettings_Rect(),
+                hexSettings = CreateDefaultSettings_Hex()
+            };
+
+            if (EditorPrefs.HasKey(CreateKey("SourceId")))
+            {
+                var idStr = EditorPrefs.GetString(CreateKey("SourceId"));
+                if (GlobalObjectId.TryParse(idStr, out var id))
+                {
+                    data.source = GlobalObjectId.GlobalObjectIdentifierToObjectSlow(id) as Tilemap;
+                }
+            }
+            else if (EditorPrefs.HasKey(CreateKey("SourcePath")))
+            {
+                var path = EditorPrefs.GetString(CreateKey("SourcePath"));
+                data.source = AssetDatabase.LoadAssetAtPath<Tilemap>(path);
+            }
+
+            data.canMergeEdges = EditorPrefs.GetBool(CreateKey("CanMergeEdges"), data.canMergeEdges);
+            data.canAttachCollider = EditorPrefs.GetBool(CreateKey("AttachCollider"), data.canAttachCollider);
+
+            foreach (var kv in data.rectSettings)
+            {
+                string name = kv.Key.ToString();
+                var setting = kv.Value;
+                setting.flags = (ShapeFlags)EditorPrefs.GetInt(CreateKey($"{name}.Flags"), (int)setting.flags);
+                setting.layer = EditorPrefs.GetInt(CreateKey($"{name}.Layer"), setting.layer);
+                setting.tag = EditorPrefs.GetString(CreateKey($"{name}.Tag"), setting.tag);
+                setting.canPreview = EditorPrefs.GetBool(CreateKey($"{name}.CanPreview"), setting.canPreview);
+                string col = EditorPrefs.GetString(CreateKey($"{name}.Color"), ColorUtility.ToHtmlStringRGBA(setting.previewColor));
+                if (ColorUtility.TryParseHtmlString("#" + col, out var c))
+                {
+                    setting.previewColor = c;
+                }
+            }
+
+            foreach (var kv in data.hexSettings)
+            {
+                string name = kv.Key.ToString();
+                var setting = kv.Value;
+                setting.flags = (ShapeFlags)EditorPrefs.GetInt(CreateKey($"Hex.{name}.Flags"), (int)setting.flags);
+                setting.layer = EditorPrefs.GetInt(CreateKey($"Hex.{name}.Layer"), setting.layer);
+                setting.tag = EditorPrefs.GetString(CreateKey($"Hex.{name}.Tag"), setting.tag);
+                setting.canPreview = EditorPrefs.GetBool(CreateKey($"Hex.{name}.CanPreview"), setting.canPreview);
+                string col = EditorPrefs.GetString(CreateKey($"Hex.{name}.Color"), ColorUtility.ToHtmlStringRGBA(setting.previewColor));
+                if (ColorUtility.TryParseHtmlString("#" + col, out var c))
+                {
+                    setting.previewColor = c;
+                }
+            }
+
+            return data;
+        }
+
+        public void Save(TilemapSplitSettings data)
+        {
+            if (data.source != null)
+            {
+                var id = GlobalObjectId.GetGlobalObjectIdSlow(data.source);
+                EditorPrefs.SetString(CreateKey("SourceId"), id.ToString());
+            }
+            else
+            {
+                EditorPrefs.DeleteKey(CreateKey("SourceId"));
+            }
+
+            EditorPrefs.SetBool(CreateKey("CanMergeEdges"), data.canMergeEdges);
+            EditorPrefs.SetBool(CreateKey("AttachCollider"), data.canAttachCollider);
+
+            foreach (var kv in data.rectSettings)
+            {
+                string name = kv.Key.ToString();
+                var setting = kv.Value;
+                EditorPrefs.SetInt(CreateKey($"{name}.Flags"), (int)setting.flags);
+                EditorPrefs.SetInt(CreateKey($"{name}.Layer"), setting.layer);
+                EditorPrefs.SetString(CreateKey($"{name}.Tag"), setting.tag);
+                EditorPrefs.SetBool(CreateKey($"{name}.CanPreview"), setting.canPreview);
+                EditorPrefs.SetString(CreateKey($"{name}.Color"),
+                    ColorUtility.ToHtmlStringRGBA(setting.previewColor));
+            }
+
+            foreach (var kv in data.hexSettings)
+            {
+                string name = kv.Key.ToString();
+                var setting = kv.Value;
+                EditorPrefs.SetInt(CreateKey($"Hex.{name}.Flags"), (int)setting.flags);
+                EditorPrefs.SetInt(CreateKey($"Hex.{name}.Layer"), setting.layer);
+                EditorPrefs.SetString(CreateKey($"Hex.{name}.Tag"), setting.tag);
+                EditorPrefs.SetBool(CreateKey($"Hex.{name}.CanPreview"), setting.canPreview);
+                EditorPrefs.SetString(CreateKey($"Hex.{name}.Color"),
+                    ColorUtility.ToHtmlStringRGBA(setting.previewColor));
+            }
+        }
+
+        public TilemapSplitSettings Reset()
+        {
+            EditorPrefs.DeleteKey(CreateKey("SourceId"));
+            EditorPrefs.DeleteKey(CreateKey("SourcePath"));
+            EditorPrefs.DeleteKey(CreateKey("CanMergeEdges"));
+            EditorPrefs.DeleteKey(CreateKey("AttachCollider"));
+
+            foreach (ShapeType_Rect t in Enum.GetValues(typeof(ShapeType_Rect)))
+            {
+                string name = t.ToString();
+                EditorPrefs.DeleteKey(CreateKey($"{name}.Flags"));
+                EditorPrefs.DeleteKey(CreateKey($"{name}.Layer"));
+                EditorPrefs.DeleteKey(CreateKey($"{name}.Tag"));
+                EditorPrefs.DeleteKey(CreateKey($"{name}.CanPreview"));
+                EditorPrefs.DeleteKey(CreateKey($"{name}.Color"));
+            }
+
+            foreach (ShapeType_Hex t in Enum.GetValues(typeof(ShapeType_Hex)))
+            {
+                string name = t.ToString();
+                EditorPrefs.DeleteKey(CreateKey($"Hex.{name}.Flags"));
+                EditorPrefs.DeleteKey(CreateKey($"Hex.{name}.Layer"));
+                EditorPrefs.DeleteKey(CreateKey($"Hex.{name}.Tag"));
+                EditorPrefs.DeleteKey(CreateKey($"Hex.{name}.CanPreview"));
+                EditorPrefs.DeleteKey(CreateKey($"Hex.{name}.Color"));
+            }
+
+            return new TilemapSplitSettings
+            {
+                rectSettings = CreateDefaultSettings_Rect(),
+                hexSettings = CreateDefaultSettings_Hex(),
+                source = null,
+                canMergeEdges = false,
+                canAttachCollider = false
+            };
+        }
+
+        public static Dictionary<ShapeType_Rect, ShapeSetting> CreateDefaultSettings_Rect() => new()
+        {
+            [ShapeType_Rect.VerticalEdge]   = new() { flags = ShapeFlags.VerticalEdge,   previewColor = Color.green  },
+            [ShapeType_Rect.HorizontalEdge] = new() { flags = ShapeFlags.HorizontalEdge, previewColor = Color.yellow },
+            [ShapeType_Rect.Cross]          = new() { flags = ShapeFlags.Independent,    previewColor = Color.red    },
+            [ShapeType_Rect.TJunction]      = new() { flags = ShapeFlags.Independent,    previewColor = Color.blue   },
+            [ShapeType_Rect.Corner]         = new() { flags = ShapeFlags.Independent,    previewColor = Color.cyan   },
+            [ShapeType_Rect.Isolate]        = new() { flags = ShapeFlags.Independent,    previewColor = Color.magenta },
+        };
+
+        public static Dictionary<ShapeType_Hex, ShapeSetting> CreateDefaultSettings_Hex() => new()
+        {
+            [ShapeType_Hex.Full]      = new() { flags = ShapeFlags.Independent, previewColor = Color.red    },
+            [ShapeType_Hex.Junction5] = new() { flags = ShapeFlags.Independent, previewColor = Color.blue   },
+            [ShapeType_Hex.Junction4] = new() { flags = ShapeFlags.Independent, previewColor = Color.cyan   },
+            [ShapeType_Hex.Junction3] = new() { flags = ShapeFlags.Independent, previewColor = Color.green  },
+            [ShapeType_Hex.Edge]      = new() { flags = ShapeFlags.Independent, previewColor = Color.yellow },
+            [ShapeType_Hex.Tip]       = new() { flags = ShapeFlags.Independent, previewColor = Color.magenta },
+            [ShapeType_Hex.Isolate]   = new() { flags = ShapeFlags.Independent, previewColor = Color.gray   },
+        };
+    }
+}

--- a/Packages/com.sunagimo.tilemapsplitter/Editor/TilemapSplitSettingsRepository.cs.meta
+++ b/Packages/com.sunagimo.tilemapsplitter/Editor/TilemapSplitSettingsRepository.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1634adb7d2e548208c084c1b4b058688

--- a/Packages/com.sunagimo.tilemapsplitter/Editor/TilemapSplitterService.cs
+++ b/Packages/com.sunagimo.tilemapsplitter/Editor/TilemapSplitterService.cs
@@ -1,0 +1,135 @@
+namespace TilemapSplitter
+{
+    using System.Collections;
+    using Unity.EditorCoroutines.Editor;
+    using UnityEditor;
+    using UnityEngine;
+    using UnityEngine.Tilemaps;
+
+    /// <summary>
+    /// 分割処理やプレビューを担当するサービス
+    /// </summary>
+    internal class TilemapSplitterService
+    {
+        private TilemapSplitSettings settings;
+        private ICellLayoutStrategy layoutStrategy;
+        private readonly TilemapPreviewDrawer previewDrawer = new();
+        private bool isRefreshingPreview;
+
+        public TilemapSplitterService(TilemapSplitSettings settings)
+        {
+            this.settings = settings;
+        }
+
+        public TilemapSplitSettings Settings => settings;
+
+        public Tilemap Source { get => settings.source; set => settings.source = value; }
+        public bool CanMergeEdges { get => settings.canMergeEdges; set => settings.canMergeEdges = value; }
+        public bool CanAttachCollider { get => settings.canAttachCollider; set => settings.canAttachCollider = value; }
+        public System.Collections.Generic.Dictionary<ShapeType_Rect, ShapeSetting> RectSettings => settings.rectSettings;
+        public System.Collections.Generic.Dictionary<ShapeType_Hex, ShapeSetting> HexSettings => settings.hexSettings;
+        public ICellLayoutStrategy LayoutStrategy => layoutStrategy;
+
+        public void ApplySettings(TilemapSplitSettings newSettings)
+        {
+            settings = newSettings;
+        }
+
+        public void RegisterPreview() => previewDrawer.Register();
+        public void UnregisterPreview() => previewDrawer.Unregister();
+
+        public void SetupLayoutStrategy(EditorWindow window)
+        {
+            if (Source == null) return;
+            var layout = Source.layoutGrid.cellLayout;
+            layoutStrategy = (layout == GridLayout.CellLayout.Hexagon)
+                ? new CellLayoutStrategy_Hex(HexSettings, () => RefreshPreview(window))
+                : new CellLayoutStrategy_Rect(RectSettings, () => RefreshPreview(window));
+        }
+
+        public void SetupPreview()
+        {
+            layoutStrategy?.SetupPreview(Source, previewDrawer);
+        }
+
+        public void RefreshPreview(EditorWindow window)
+        {
+            if (Source == null || isRefreshingPreview || layoutStrategy == null) return;
+            EditorCoroutineUtility.StartCoroutine(RefreshPreviewCoroutine(), window);
+
+            IEnumerator RefreshPreviewCoroutine()
+            {
+                isRefreshingPreview = true;
+
+                var progress = new CancelableProgressBar("分類");
+                IEnumerator<bool> e = layoutStrategy.Classify(Source, progress, () => progress.IsCancelled);
+                while (e.MoveNext())
+                {
+                    if (e.Current)
+                    {
+                        progress.Clear();
+                        isRefreshingPreview = false;
+                        yield break;
+                    }
+                    yield return null;
+                }
+
+                progress.Clear();
+                layoutStrategy.SetupPreview(Source, previewDrawer);
+                layoutStrategy.SetShapeCellsToPreview(previewDrawer);
+                SceneView.RepaintAll();
+                layoutStrategy.UpdateFoldoutTitles();
+
+                isRefreshingPreview = false;
+            }
+        }
+
+        public void ExecuteSplit(EditorWindow window)
+        {
+            EditorCoroutineUtility.StartCoroutine(SplitCoroutine(), window);
+
+            IEnumerator SplitCoroutine()
+            {
+                var progress = new CancelableProgressBar("分類");
+                IEnumerator<bool> e = layoutStrategy.Classify(Source, progress, () => progress.IsCancelled);
+                while (e.MoveNext())
+                {
+                    if (e.Current)
+                    {
+                        progress.Clear();
+                        yield break;
+                    }
+                    yield return null;
+                }
+                progress.Clear();
+                layoutStrategy.GenerateSplitTilemaps(Source, CanMergeEdges, CanAttachCollider);
+                RefreshPreview(window);
+            }
+        }
+
+        /// <summary>
+        /// キャンセル可能なプログレスバー
+        /// </summary>
+        private sealed class CancelableProgressBar : IProgress<float>
+        {
+            private readonly string title;
+            public bool IsCancelled { get; private set; }
+
+            public CancelableProgressBar(string title)
+            {
+                this.title = title;
+            }
+
+            public void Report(float value)
+            {
+                IsCancelled = EditorUtility.DisplayCancelableProgressBar(
+                    title, $"分類中... {Mathf.RoundToInt(value * 100)}%", value);
+            }
+
+            public void Clear()
+            {
+                EditorUtility.ClearProgressBar();
+            }
+        }
+    }
+}

--- a/Packages/com.sunagimo.tilemapsplitter/Editor/TilemapSplitterService.cs.meta
+++ b/Packages/com.sunagimo.tilemapsplitter/Editor/TilemapSplitterService.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f5338654ba3e4553affba7e289a36a62

--- a/Packages/com.sunagimo.tilemapsplitter/Editor/TilemapSplitterUI.cs
+++ b/Packages/com.sunagimo.tilemapsplitter/Editor/TilemapSplitterUI.cs
@@ -1,0 +1,108 @@
+namespace TilemapSplitter
+{
+    using UnityEditor;
+    using UnityEditor.UIElements;
+    using UnityEngine;
+    using UnityEngine.Tilemaps;
+    using UnityEngine.UIElements;
+
+    /// <summary>
+    /// ウィンドウのUI構築を担当するクラス
+    /// </summary>
+    internal static class TilemapSplitterUI
+    {
+        public static void Build(TilemapSplitterWindow window, TilemapSplitterService service)
+        {
+            var container = CreateScrollableContainer(window.rootVisualElement);
+            CreateSourceField(container, service, window);
+            CreateResetButton(container, window);
+            CreateColliderToggle(container, service);
+
+            if (service.Source == null || service.Source.gameObject.activeInHierarchy == false) return;
+
+            service.SetupLayoutStrategy(window);
+            service.LayoutStrategy.CreateMergeEdgeToggle(container, () => service.CanMergeEdges, v => service.CanMergeEdges = v);
+            service.LayoutStrategy.CreateShapeFoldouts(container);
+
+            CreateExecuteButton(container, service, window);
+
+            service.SetupPreview();
+            service.RefreshPreview(window);
+        }
+
+        private static VisualElement CreateScrollableContainer(VisualElement root)
+        {
+            var scroll = new ScrollView();
+            var container = new VisualElement();
+            container.style.flexDirection = FlexDirection.Column;
+            container.style.paddingLeft = 10;
+            container.style.paddingRight = 10;
+            root.Add(scroll);
+            scroll.Add(container);
+
+            AddHorizontalSeparator(container);
+            return container;
+        }
+
+        private static void CreateSourceField(VisualElement container, TilemapSplitterService service, TilemapSplitterWindow window)
+        {
+            var sourceF = new ObjectField("Split Tilemap");
+            var hp = new HelpBox("Select the subject of the division", HelpBoxMessageType.Info);
+            sourceF.objectType = typeof(Tilemap);
+            sourceF.value = service.Source;
+            sourceF.RegisterValueChangedCallback(evt =>
+            {
+                service.Source = evt.newValue as Tilemap;
+                hp.visible = (service.Source == null);
+
+                window.CreateGUI();
+                service.RefreshPreview(window);
+            });
+            hp.visible = (service.Source == null);
+            container.Add(sourceF);
+            container.Add(hp);
+        }
+
+        private static void CreateResetButton(VisualElement container, TilemapSplitterWindow window)
+        {
+            var resetB = new Button(() => window.ResetSettings());
+            resetB.text = "Reset Settings";
+            resetB.style.marginTop = 5;
+            container.Add(resetB);
+        }
+
+        private static void CreateColliderToggle(VisualElement container, TilemapSplitterService service)
+        {
+            var attachT = new Toggle("Attach Colliders");
+            attachT.value = service.CanAttachCollider;
+            attachT.RegisterValueChangedCallback(evt => service.CanAttachCollider = evt.newValue);
+            container.Add(attachT);
+        }
+
+        private static void CreateExecuteButton(VisualElement container, TilemapSplitterService service, TilemapSplitterWindow window)
+        {
+            var splitB = new Button(() =>
+            {
+                if (service.Source == null)
+                {
+                    EditorUtility.DisplayDialog("Error", "The split target isn't set", "OK");
+                    return;
+                }
+                service.ExecuteSplit(window);
+            });
+            splitB.text = "Execute Splitting";
+            splitB.style.marginTop = 10;
+            container.Add(splitB);
+        }
+
+        public static void AddHorizontalSeparator(VisualElement parentContainer)
+        {
+            var separator = new VisualElement();
+            separator.style.borderBottomWidth = 1;
+            separator.style.borderBottomColor = Color.gray;
+            separator.style.marginTop = 5;
+            separator.style.marginBottom = 5;
+            parentContainer.Add(separator);
+        }
+    }
+}

--- a/Packages/com.sunagimo.tilemapsplitter/Editor/TilemapSplitterUI.cs.meta
+++ b/Packages/com.sunagimo.tilemapsplitter/Editor/TilemapSplitterUI.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 24e388d6677a45bd8279323dd258edff

--- a/Packages/com.sunagimo.tilemapsplitter/Editor/TilemapSplitterWindow.cs
+++ b/Packages/com.sunagimo.tilemapsplitter/Editor/TilemapSplitterWindow.cs
@@ -1,377 +1,42 @@
 namespace TilemapSplitter
 {
-    using System;
-    using System.Collections;
-    using System.Collections.Generic;
     using UnityEditor;
-    using UnityEditor.UIElements;
-    using Unity.EditorCoroutines.Editor;
     using UnityEngine;
-    using UnityEngine.Tilemaps;
-    using UnityEngine.UIElements;
 
     /// <summary>
-    /// Editor window that splits a tilemap into multiple parts based on cell layout
+    /// タイルマップ分割ウィンドウ
     /// </summary>
     internal class TilemapSplitterWindow : EditorWindow
     {
-        private const string PrefPrefix = "TilemapSplitter.";
-        private static string CreateKey(string name) => PrefPrefix + name;
-
-        private Dictionary<ShapeType_Rect, ShapeSetting> settingsDict_rect = CreateDefaultSettings_Rect();
-        private Dictionary<ShapeType_Hex, ShapeSetting>  settingsDict_hex  = CreateDefaultSettings_Hex();
-
-        private static Dictionary<ShapeType_Rect, ShapeSetting> CreateDefaultSettings_Rect() => new()
-        {
-            [ShapeType_Rect.VerticalEdge]   = new() { flags = ShapeFlags.VerticalEdge,   previewColor = Color.green  },
-            [ShapeType_Rect.HorizontalEdge] = new() { flags = ShapeFlags.HorizontalEdge, previewColor = Color.yellow },
-            [ShapeType_Rect.Cross]          = new() { flags = ShapeFlags.Independent,    previewColor = Color.red    },
-            [ShapeType_Rect.TJunction]      = new() { flags = ShapeFlags.Independent,    previewColor = Color.blue   },
-            [ShapeType_Rect.Corner]         = new() { flags = ShapeFlags.Independent,    previewColor = Color.cyan   },
-            [ShapeType_Rect.Isolate]        = new() { flags = ShapeFlags.Independent,    previewColor = Color.magenta },
-        };
-        private static Dictionary<ShapeType_Hex, ShapeSetting> CreateDefaultSettings_Hex() => new()
-        {
-            [ShapeType_Hex.Full]      = new() { flags = ShapeFlags.Independent, previewColor = Color.red    },
-            [ShapeType_Hex.Junction5] = new() { flags = ShapeFlags.Independent, previewColor = Color.blue   },
-            [ShapeType_Hex.Junction4] = new() { flags = ShapeFlags.Independent, previewColor = Color.cyan   },
-            [ShapeType_Hex.Junction3] = new() { flags = ShapeFlags.Independent, previewColor = Color.green  },
-            [ShapeType_Hex.Edge]      = new() { flags = ShapeFlags.Independent, previewColor = Color.yellow },
-            [ShapeType_Hex.Tip]       = new() { flags = ShapeFlags.Independent, previewColor = Color.magenta },
-            [ShapeType_Hex.Isolate]   = new() { flags = ShapeFlags.Independent, previewColor = Color.gray   },
-        };
-
-        private Tilemap source;
-
-        private ICellLayoutStrategy layoutStrategy;
-
-        private readonly TilemapPreviewDrawer previewDrawer = new();
-
-        private bool canMergeEdges       = false;
-        private bool canAttachCollider   = false;
-        private bool isRefreshingPreview = false;
-
-        // Progress bar that supports cancellation
-        private sealed class CancelableProgressBar : IProgress<float>
-        {
-            private readonly string title;
-            public bool IsCancelled { get; private set; }
-
-            public CancelableProgressBar(string title)
-            {
-                this.title = title;
-            }
-
-            public void Report(float value)
-            {
-                IsCancelled = EditorUtility.DisplayCancelableProgressBar(
-                    title, $"分類中... {Mathf.RoundToInt(value * 100)}%", value);
-            }
-
-            public void Clear()
-            {
-                EditorUtility.ClearProgressBar();
-            }
-        }
+        private readonly TilemapSplitSettingsRepository repository = new();
+        private TilemapSplitterService service;
 
         [MenuItem("Tools/TilemapSplitter")]
         public static void ShowWindow() => GetWindow<TilemapSplitterWindow>("Split Tilemap");
 
         private void OnEnable()
         {
-            LoadPrefs();
-            previewDrawer.Register();
+            var data = repository.Load();
+            service = new TilemapSplitterService(data);
+            service.RegisterPreview();
         }
 
         private void OnDisable()
         {
-            SavePrefs();
-            previewDrawer.Unregister();
+            repository.Save(service.Settings);
+            service.UnregisterPreview();
         }
 
         public void CreateGUI()
         {
-            var c = CreateScrollableContainer();
-            CreateSourceField(c);
-            CreateResetButton(c);
-            CreateColliderToggle(c);
-
-            if (source == null || source.gameObject.activeInHierarchy == false) return;
-
-            var layout = source.layoutGrid.cellLayout;
-            layoutStrategy = (layout == GridLayout.CellLayout.Hexagon)
-                ? new CellLayoutStrategy_Hex(settingsDict_hex, RefreshPreview)
-                : new CellLayoutStrategy_Rect(settingsDict_rect, RefreshPreview);
-
-            layoutStrategy.CreateMergeEdgeToggle(c, () => canMergeEdges, v => canMergeEdges = v);
-            layoutStrategy.CreateShapeFoldouts(c);
-
-            CreateExecuteButton(c);
-
-            layoutStrategy.SetupPreview(source, previewDrawer);
-            RefreshPreview();
+            rootVisualElement.Clear();
+            TilemapSplitterUI.Build(this, service);
         }
 
-        private VisualElement CreateScrollableContainer()
+        public void ResetSettings()
         {
-            //Create a ScrollView and a container VisualElement
-            var scroll    = new ScrollView();
-            var container = new VisualElement();
-            container.style.flexDirection = FlexDirection.Column;
-            container.style.paddingLeft   = 10;
-            container.style.paddingRight  = 10;
-            rootVisualElement.Add(scroll);
-            scroll.Add(container);
-
-            AddHorizontalSeparator(container);
-            return container;
+            service.ApplySettings(repository.Reset());
+            CreateGUI();
         }
-
-        private void CreateSourceField(VisualElement container)
-        {
-            var sourceF = new ObjectField("Split Tilemap");
-            var hp      = new HelpBox("Select the subject of the division", HelpBoxMessageType.Info);
-            sourceF.objectType = typeof(Tilemap);
-            sourceF.value      = source;
-            sourceF.RegisterValueChangedCallback(evt =>
-            {
-                source     = evt.newValue as Tilemap;
-                hp.visible = (source == null);
-
-                rootVisualElement.Clear();
-                CreateGUI();
-                RefreshPreview();
-            });
-            hp.visible = (source == null);
-            container.Add(sourceF);
-            container.Add(hp);
-        }
-
-        private void CreateResetButton(VisualElement container)
-        {
-            var resetB = new Button(() =>
-            {
-                ResetPrefs();
-                rootVisualElement.Clear();
-                CreateGUI();
-            });
-            resetB.text            = "Reset Settings";
-            resetB.style.marginTop = 5;
-            container.Add(resetB);
-        }
-
-        private void CreateColliderToggle(VisualElement container)
-        {
-            var attachT   = new Toggle("Attach Colliders");
-            attachT.value = canAttachCollider;
-            attachT.RegisterValueChangedCallback(evt => canAttachCollider = evt.newValue);
-            container.Add(attachT);
-        }
-
-        private void CreateExecuteButton(VisualElement container)
-        {
-            var splitB = new Button(() =>
-            {
-                if (source == null)
-                {
-                    EditorUtility.DisplayDialog("Error", "The split target isn't set", "OK");
-                    return;
-                }
-                EditorCoroutineUtility.StartCoroutine(SplitCoroutine(), this);
-            });
-            splitB.text            = "Execute Splitting";
-            splitB.style.marginTop = 10;
-            container.Add(splitB);
-        }
-
-        public static void AddHorizontalSeparator(VisualElement parentContainer)
-        {
-            var separator = new VisualElement();
-            separator.style.borderBottomWidth = 1;
-            separator.style.borderBottomColor = Color.gray;
-            separator.style.marginTop         = 5;
-            separator.style.marginBottom      = 5;
-            parentContainer.Add(separator);
-        }
-
-        private IEnumerator SplitCoroutine()
-        {
-            var progress = new CancelableProgressBar("分類");
-            IEnumerator<bool> e = layoutStrategy.Classify(source, progress, () => progress.IsCancelled);
-            while (e.MoveNext())
-            {
-                if (e.Current)
-                {
-                    progress.Clear();
-                    yield break;
-                }
-                yield return null;
-            }
-            progress.Clear();
-            layoutStrategy.GenerateSplitTilemaps(source, canMergeEdges, canAttachCollider);
-            RefreshPreview();
-        }
-
-        private void RefreshPreview()
-        {
-            if (source == null || isRefreshingPreview || layoutStrategy == null) return;
-            EditorCoroutineUtility.StartCoroutine(RefreshPreviewCoroutine(), this);
-
-            IEnumerator RefreshPreviewCoroutine()
-            {
-                isRefreshingPreview = true;
-
-                var progress = new CancelableProgressBar("分類");
-                IEnumerator<bool> e = layoutStrategy.Classify(source, progress, () => progress.IsCancelled);
-                while (e.MoveNext())
-                {
-                    if (e.Current)
-                    {
-                        progress.Clear();
-                        isRefreshingPreview = false;
-                        yield break;
-                    }
-                    yield return null;
-                }
-
-                progress.Clear();
-                layoutStrategy.SetupPreview(source, previewDrawer);
-                layoutStrategy.SetShapeCellsToPreview(previewDrawer);
-                SceneView.RepaintAll();
-                layoutStrategy.UpdateFoldoutTitles();
-
-                isRefreshingPreview = false;
-            }
-        }
-
-        #region Saving and Loading Split Settings using EditorPrefs
-
-        private void SavePrefs()
-        {
-            if (source != null)
-            {
-                var id = GlobalObjectId.GetGlobalObjectIdSlow(source);
-                EditorPrefs.SetString(CreateKey("SourceId"), id.ToString());
-            }
-            else
-            {
-                EditorPrefs.DeleteKey(CreateKey("SourceId"));
-            }
-
-            EditorPrefs.SetBool(CreateKey("CanMergeEdges"),  canMergeEdges);
-            EditorPrefs.SetBool(CreateKey("AttachCollider"), canAttachCollider);
-
-            foreach (var kv in settingsDict_rect)
-            {
-                string name = kv.Key.ToString();
-                var setting = kv.Value;
-                EditorPrefs.SetInt(CreateKey($"{name}.Flags"), (int)setting.flags);
-                EditorPrefs.SetInt(CreateKey($"{name}.Layer"), setting.layer);
-                EditorPrefs.SetString(CreateKey($"{name}.Tag"), setting.tag);
-                EditorPrefs.SetBool(CreateKey($"{name}.CanPreview"), setting.canPreview);
-                EditorPrefs.SetString(CreateKey($"{name}.Color"),
-                    ColorUtility.ToHtmlStringRGBA(setting.previewColor));
-            }
-
-            foreach (var kv in settingsDict_hex)
-            {
-                string name = kv.Key.ToString();
-                var setting = kv.Value;
-                EditorPrefs.SetInt(CreateKey($"Hex.{name}.Flags"), (int)setting.flags);
-                EditorPrefs.SetInt(CreateKey($"Hex.{name}.Layer"), setting.layer);
-                EditorPrefs.SetString(CreateKey($"Hex.{name}.Tag"), setting.tag);
-                EditorPrefs.SetBool(CreateKey($"Hex.{name}.CanPreview"), setting.canPreview);
-                EditorPrefs.SetString(CreateKey($"Hex.{name}.Color"),
-                    ColorUtility.ToHtmlStringRGBA(setting.previewColor));
-            }
-        }
-
-        private void LoadPrefs()
-        {
-            if (EditorPrefs.HasKey(CreateKey("SourceId")))
-            {
-                var idStr = EditorPrefs.GetString(CreateKey("SourceId"));
-                if (GlobalObjectId.TryParse(idStr, out var id))
-                {
-                    source = GlobalObjectId.GlobalObjectIdentifierToObjectSlow(id) as Tilemap;
-                }
-            }
-            else if (EditorPrefs.HasKey(CreateKey("SourcePath")))
-            {
-                var path = EditorPrefs.GetString(CreateKey("SourcePath"));
-                source   = AssetDatabase.LoadAssetAtPath<Tilemap>(path);
-            }
-
-            canMergeEdges     = EditorPrefs.GetBool(CreateKey("CanMergeEdges"), canMergeEdges);
-            canAttachCollider = EditorPrefs.GetBool(CreateKey("AttachCollider"), canAttachCollider);
-
-            foreach (var kv in settingsDict_rect)
-            {
-                var name    = kv.Key.ToString();
-                var setting = kv.Value;
-                setting.flags      = (ShapeFlags)EditorPrefs.GetInt(CreateKey($"{name}.Flags"), (int)setting.flags);
-                setting.layer      = EditorPrefs.GetInt(CreateKey($"{name}.Layer"), setting.layer);
-                setting.tag        = EditorPrefs.GetString(CreateKey($"{name}.Tag"), setting.tag);
-                setting.canPreview = EditorPrefs.GetBool(CreateKey($"{name}.CanPreview"), setting.canPreview);
-                string col = EditorPrefs.GetString(CreateKey($"{name}.Color"),
-                    ColorUtility.ToHtmlStringRGBA(setting.previewColor));
-                if (ColorUtility.TryParseHtmlString("#" + col, out var c))
-                {
-                    setting.previewColor = c;
-                }
-            }
-
-            foreach (var kv in settingsDict_hex)
-            {
-                var name    = kv.Key.ToString();
-                var setting = kv.Value;
-                setting.flags      = (ShapeFlags)EditorPrefs.GetInt(CreateKey($"Hex.{name}.Flags"), (int)setting.flags);
-                setting.layer      = EditorPrefs.GetInt(CreateKey($"Hex.{name}.Layer"), setting.layer);
-                setting.tag        = EditorPrefs.GetString(CreateKey($"Hex.{name}.Tag"), setting.tag);
-                setting.canPreview = EditorPrefs.GetBool(CreateKey($"Hex.{name}.CanPreview"), setting.canPreview);
-                string col = EditorPrefs.GetString(CreateKey($"Hex.{name}.Color"),
-                    ColorUtility.ToHtmlStringRGBA(setting.previewColor));
-                if (ColorUtility.TryParseHtmlString("#" + col, out var c))
-                {
-                    setting.previewColor = c;
-                }
-            }
-        }
-
-        private void ResetPrefs()
-        {
-            EditorPrefs.DeleteKey(CreateKey("SourceId"));
-            EditorPrefs.DeleteKey(CreateKey("SourcePath"));
-            EditorPrefs.DeleteKey(CreateKey("CanMergeEdges"));
-            EditorPrefs.DeleteKey(CreateKey("AttachCollider"));
-
-            foreach (ShapeType_Rect t in Enum.GetValues(typeof(ShapeType_Rect)))
-            {
-                string name = t.ToString();
-                EditorPrefs.DeleteKey(CreateKey($"{name}.Flags"));
-                EditorPrefs.DeleteKey(CreateKey($"{name}.Layer"));
-                EditorPrefs.DeleteKey(CreateKey($"{name}.Tag"));
-                EditorPrefs.DeleteKey(CreateKey($"{name}.CanPreview"));
-                EditorPrefs.DeleteKey(CreateKey($"{name}.Color"));
-            }
-
-            foreach (ShapeType_Hex t in Enum.GetValues(typeof(ShapeType_Hex)))
-            {
-                string name = t.ToString();
-                EditorPrefs.DeleteKey(CreateKey($"Hex.{name}.Flags"));
-                EditorPrefs.DeleteKey(CreateKey($"Hex.{name}.Layer"));
-                EditorPrefs.DeleteKey(CreateKey($"Hex.{name}.Tag"));
-                EditorPrefs.DeleteKey(CreateKey($"Hex.{name}.CanPreview"));
-                EditorPrefs.DeleteKey(CreateKey($"Hex.{name}.Color"));
-            }
-
-            settingsDict_rect      = CreateDefaultSettings_Rect();
-            settingsDict_hex   = CreateDefaultSettings_Hex();
-            source            = null;
-            canMergeEdges     = false;
-            canAttachCollider = false;
-        }
-
-        #endregion
     }
 }


### PR DESCRIPTION
## 概要
- 設定保存処理を TilemapSplitSettingsRepository に抽出
- 分割実行とプレビューを TilemapSplitterService に委譲
- UI 構築を TilemapSplitterUI に切り出しウィンドウは組み立て専任化

## テスト
- `dotnet test` (dotnet が見つからず失敗)
- `apt-get update` (403 Forbidden により失敗)


------
https://chatgpt.com/codex/tasks/task_e_689366f1ca94832ab05660ce0ba31224